### PR TITLE
Cache merkleization for some types

### DIFF
--- a/ssz_rs/examples/another_container.rs
+++ b/ssz_rs/examples/another_container.rs
@@ -39,7 +39,7 @@ struct ComplexTestStruct {
 }
 
 fn main() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 51972,
         b: List::<u16, 128>::from_iter([48645]),
         c: 46,

--- a/ssz_rs/examples/container_with_some_types.rs
+++ b/ssz_rs/examples/container_with_some_types.rs
@@ -59,7 +59,7 @@ fn main() {
         }
     };
 
-    let restored_foo = match Foo::<4>::deserialize(&encoding) {
+    let mut restored_foo = match Foo::<4>::deserialize(&encoding) {
         Ok(value) => value,
         Err(e) => {
             eprintln!("some error decoding: {}", e);

--- a/ssz_rs/scripts/README.md
+++ b/ssz_rs/scripts/README.md
@@ -11,3 +11,9 @@ $ truncate --size 0 ../tests/$TYPE.rs && python gen.py $TYPE >> ../tests/$TYPE.r
 $ mv ssz_rs/tests/data ../tests && rm -rf ssz_rs
 ```
 where `$TYPE` is one of: `boolean, uints, basic_vector, bitlist, bitvector, containers`.
+
+or to generate new test code, altogether:
+
+```bash
+for TYPE in boolean uints basic_vector bitlist bitvector containers; do truncate --size 0 ../tests/$TYPE.rs && python gen.py $TYPE >> ../tests/$TYPE.rs && rustfmt ../tests/$TYPE.rs; done
+```

--- a/ssz_rs/scripts/gen.py
+++ b/ssz_rs/scripts/gen.py
@@ -66,7 +66,7 @@ struct BitsStruct {
 valid_test_fmt = """
 #[test]
 fn test_{type}_{handler}() {{
-    let value = {value};
+    let mut value = {value};
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("{data_path}");
     assert_eq!(encoding, expected_encoding);
@@ -74,7 +74,7 @@ fn test_{type}_{handler}() {{
     let recovered_value: {rust_type} = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root = root_from_hex("{root}");
     assert_eq!(root, expected_root);
 }}

--- a/ssz_rs/src/array.rs
+++ b/ssz_rs/src/array.rs
@@ -66,10 +66,10 @@ macro_rules! define_ssz_for_array_of_size {
         where
             T: SimpleSerialize,
         {
-            fn hash_tree_root(&self, context: &Context) -> Result<Node, MerkleizationError> {
+            fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
                 if T::is_composite_type() {
                     let mut chunks = vec![0u8; self.len() * BYTES_PER_CHUNK];
-                    for (i, elem) in self.iter().enumerate() {
+                    for (i, elem) in self.iter_mut().enumerate() {
                         let chunk = elem.hash_tree_root(context)?;
                         let range = i * BYTES_PER_CHUNK..(i + 1) * BYTES_PER_CHUNK;
                         chunks[range].copy_from_slice(chunk.as_ref());

--- a/ssz_rs/src/bitlist.rs
+++ b/ssz_rs/src/bitlist.rs
@@ -154,7 +154,7 @@ impl<const N: usize> Deserialize for Bitlist<N> {
 }
 
 impl<const N: usize> Merkleized for Bitlist<N> {
-    fn hash_tree_root(&self, context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
         let chunks = self.pack_bits()?;
         let data_root = merkleize(&chunks, Some((N + 255) / 256), context)?;
         Ok(mix_in_length(&data_root, self.len(), context))

--- a/ssz_rs/src/bitvector.rs
+++ b/ssz_rs/src/bitvector.rs
@@ -140,7 +140,7 @@ impl<const N: usize> Deserialize for Bitvector<N> {
 }
 
 impl<const N: usize> Merkleized for Bitvector<N> {
-    fn hash_tree_root(&self, context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
         let chunks = self.pack_bits()?;
         merkleize(&chunks, Some((N + 255) / 256), context)
     }

--- a/ssz_rs/src/boolean.rs
+++ b/ssz_rs/src/boolean.rs
@@ -36,7 +36,7 @@ impl Deserialize for bool {
 }
 
 impl Merkleized for bool {
-    fn hash_tree_root(&self, _context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self, _context: &Context) -> Result<Node, MerkleizationError> {
         if *self {
             let mut root = Node::default();
             root[0] = 1u8;

--- a/ssz_rs/src/merkleization/cache.rs
+++ b/ssz_rs/src/merkleization/cache.rs
@@ -1,0 +1,44 @@
+use crate::merkleization::Node;
+use bitvec::prelude::{bitvec, BitVec};
+
+#[derive(Default, Debug, Clone)]
+pub struct Cache {
+    leaf_count: usize,
+    dirty_leaves: BitVec,
+    root: Node,
+}
+
+impl Cache {
+    pub fn with_leaves(leaf_count: usize) -> Self {
+        Self {
+            leaf_count,
+            dirty_leaves: bitvec![1; leaf_count],
+            ..Default::default()
+        }
+    }
+
+    pub fn valid(&self) -> bool {
+        let has_dirty_leaves = self.dirty_leaves.any();
+        let did_resize = self.leaf_count != self.dirty_leaves.len();
+        !(has_dirty_leaves || did_resize)
+    }
+
+    pub fn invalidate(&mut self, leaf_index: usize) {
+        if let Some(mut bit) = self.dirty_leaves.get_mut(leaf_index) {
+            // TODO: unconditionally access bit
+            *bit = true;
+        }
+    }
+
+    pub fn resize(&mut self, bound: usize) {
+        self.dirty_leaves.resize(bound, true);
+    }
+
+    pub fn update(&mut self, root: Node) {
+        self.root = root;
+    }
+
+    pub fn root(&self) -> Node {
+        self.root
+    }
+}

--- a/ssz_rs/src/uint.rs
+++ b/ssz_rs/src/uint.rs
@@ -42,7 +42,7 @@ macro_rules! define_uint {
         }
 
         impl Merkleized for $uint {
-            fn hash_tree_root(&self, _context: &Context) -> Result<Node, MerkleizationError> {
+            fn hash_tree_root(&mut self, _context: &Context) -> Result<Node, MerkleizationError> {
                 let mut root = vec![];
                 let _ = self.serialize(&mut root)?;
                 pack_bytes(&mut root);
@@ -102,7 +102,7 @@ impl Deserialize for U256 {
 }
 
 impl Merkleized for U256 {
-    fn hash_tree_root(&self, _context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self, _context: &Context) -> Result<Node, MerkleizationError> {
         Ok(Node::from_bytes(self.0))
     }
 }

--- a/ssz_rs/src/union.rs
+++ b/ssz_rs/src/union.rs
@@ -59,7 +59,7 @@ impl<T> Merkleized for Option<T>
 where
     T: SimpleSerialize,
 {
-    fn hash_tree_root(&self, context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
         match self {
             Some(value) => Ok(mix_in_selector(&value.hash_tree_root(context)?, 1, context)),
             None => Ok(mix_in_selector(&Node::default(), 0, context)),

--- a/ssz_rs/src/vector.rs
+++ b/ssz_rs/src/vector.rs
@@ -1,24 +1,63 @@
 use crate::de::{deserialize_homogeneous_composite, Deserialize, DeserializeError};
 use crate::merkleization::{
-    merkleize, pack, Context, MerkleizationError, Merkleized, Node, BYTES_PER_CHUNK,
+    merkleize, pack, Context, MerkleCache, MerkleizationError, Merkleized, Node, BYTES_PER_CHUNK,
 };
 use crate::ser::{serialize_composite, Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
+use std::convert::TryFrom;
 use std::fmt;
 use std::iter::FromIterator;
-use std::ops::{Deref, DerefMut};
+use std::ops::{Deref, Index, IndexMut};
+use std::slice::SliceIndex;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("incorrect number of elements {provided} to make a Vector of length {expected}")]
+    IncorrectLength { expected: usize, provided: usize },
+}
 
 /// A homogenous collection of a fixed number of values.
 /// NOTE: a `Vector` of length `0` is illegal.
-#[derive(PartialEq, Eq, Clone)]
-pub struct Vector<T: SimpleSerialize, const N: usize>(Vec<T>);
+#[derive(Clone)]
+pub struct Vector<T: SimpleSerialize, const N: usize> {
+    data: Vec<T>,
+    cache: MerkleCache,
+}
+
+impl<T: SimpleSerialize + PartialEq, const N: usize> PartialEq for Vector<T, N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl<T: SimpleSerialize + Eq, const N: usize> Eq for Vector<T, N> {}
+
+impl<T: SimpleSerialize, const N: usize> TryFrom<Vec<T>> for Vector<T, N> {
+    type Error = Error;
+
+    fn try_from(data: Vec<T>) -> Result<Self, Self::Error> {
+        if data.len() != N {
+            Err(Error::IncorrectLength {
+                expected: N,
+                provided: data.len(),
+            })
+        } else {
+            let leaf_count = Self::get_leaf_count();
+            Ok(Self {
+                data,
+                cache: MerkleCache::with_leaves(leaf_count),
+            })
+        }
+    }
+}
 
 impl<T, const N: usize> fmt::Debug for Vector<T, N>
 where
     T: SimpleSerialize + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "Vector<{}>{:?}", N, self.0)
+        write!(f, "Vector<{}>{:?}", N, self.data)
     }
 }
 
@@ -27,8 +66,8 @@ where
     T: SimpleSerialize + Default + Clone,
 {
     fn default() -> Self {
-        let inner = vec![T::default(); N];
-        Self(inner)
+        let data = vec![T::default(); N];
+        data.try_into().unwrap()
     }
 }
 
@@ -39,16 +78,36 @@ where
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.data
     }
 }
 
-impl<T, const N: usize> DerefMut for Vector<T, N>
+// NOTE: implement `IndexMut` rather than `DerefMut` to ensure
+// the `Vector`'s inner `Vec` is not mutated, but its elements
+// can change.
+impl<T, Idx: SliceIndex<[T]>, const N: usize> Index<Idx> for Vector<T, N>
 where
     T: SimpleSerialize,
 {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+    type Output = <Idx as SliceIndex<[T]>>::Output;
+
+    fn index(&self, index: Idx) -> &Self::Output {
+        &self.data[index]
+    }
+}
+
+// NOTE: had an issue unifying the use of `IndexMut::Idx` for `Vec`
+// and `BitVec` that may be unresolveable due to how lifetimes
+// are defined for this trait method. For now, only allow "one at a time"
+// mutation of the `Vector`s data.
+impl<T, const N: usize> IndexMut<usize> for Vector<T, N>
+where
+    T: SimpleSerialize,
+{
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        let leaf_index = self.get_leaf_index(index);
+        self.cache.invalidate(leaf_index);
+        &mut self.data[index]
     }
 }
 
@@ -73,7 +132,7 @@ where
         if N == 0 {
             return Err(SerializeError::IllegalType { bound: N });
         }
-        serialize_composite(&self.0, buffer)
+        serialize_composite(&self.data, buffer)
     }
 }
 
@@ -94,79 +153,93 @@ where
                 return Err(DeserializeError::ExtraInput);
             }
         }
-        let elements = deserialize_homogeneous_composite(encoding)?;
-        Ok(Self(elements))
+        let data = deserialize_homogeneous_composite(encoding)?;
+        data.try_into().map_err(|err| match err {
+            Error::IncorrectLength { expected, provided } => {
+                if expected < provided {
+                    DeserializeError::ExtraInput
+                } else {
+                    DeserializeError::InputTooShort
+                }
+            }
+        })
     }
 }
 
-impl<T, const N: usize> SimpleSerialize for Vector<T, N> where T: SimpleSerialize + Copy {}
-
-impl<T, const N: usize> Merkleized for Vector<T, N>
+impl<T, const N: usize> Vector<T, N>
 where
     T: SimpleSerialize,
 {
-    fn hash_tree_root(&self, context: &Context) -> Result<Node, MerkleizationError> {
+    // the number of leafs in the Merkle tree of this `Vector`
+    fn get_leaf_count() -> usize {
+        if T::is_composite_type() {
+            N
+        } else {
+            let encoded_length = Self::size_hint();
+            (encoded_length + 31) / 32
+        }
+    }
+
+    fn get_leaf_index(&self, index: usize) -> usize {
+        if T::is_composite_type() {
+            index
+        } else {
+            // TODO: compute correct leaf index
+            index + 1
+        }
+    }
+
+    fn compute_hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
         if T::is_composite_type() {
             let mut chunks = vec![0u8; self.len() * BYTES_PER_CHUNK];
-            for (i, elem) in self.iter().enumerate() {
+            for (i, elem) in self.data.iter_mut().enumerate() {
                 let chunk = elem.hash_tree_root(context)?;
                 let range = i * BYTES_PER_CHUNK..(i + 1) * BYTES_PER_CHUNK;
                 chunks[range].copy_from_slice(chunk.as_ref());
             }
             merkleize(&chunks, None, context)
         } else {
-            let chunks = pack(&self.0)?;
+            let chunks = pack(&self.data)?;
             merkleize(&chunks, None, context)
         }
     }
 }
 
+impl<T, const N: usize> Merkleized for Vector<T, N>
+where
+    T: SimpleSerialize,
+{
+    fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
+        if !self.cache.valid() {
+            // which leaves are dirty
+            // figure out which elements are needed and recompute leaves
+            // update cache w/ new leaves
+            let root = self.compute_hash_tree_root(context)?;
+            self.cache.update(root);
+        }
+        Ok(self.cache.root())
+    }
+}
+
+impl<T, const N: usize> SimpleSerialize for Vector<T, N> where T: SimpleSerialize + Clone {}
+
 impl<T, const N: usize> FromIterator<T> for Vector<T, N>
 where
-    T: SimpleSerialize + Default + Clone,
+    T: SimpleSerialize + Default,
 {
+    // Builds a `Vector<T, N>` from the iterator given by `iter`.
+    // If `iter` is more than `N` elements, then only the first `N` are taken.
+    // If `iter` is less than `N` elements, the Vector is extended with
+    // the remainder using `T::default()`.
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = T>,
     {
-        let inner = iter.into_iter().take(N).collect::<Vec<_>>();
-        Self(inner)
-    }
-}
-
-impl<T, const N: usize> IntoIterator for Vector<T, N>
-where
-    T: SimpleSerialize,
-{
-    type Item = T;
-    type IntoIter = std::vec::IntoIter<T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl<'a, T, const N: usize> IntoIterator for &'a Vector<T, N>
-where
-    T: SimpleSerialize,
-{
-    type Item = &'a T;
-    type IntoIter = std::slice::Iter<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
-impl<'a, T, const N: usize> IntoIterator for &'a mut Vector<T, N>
-where
-    T: SimpleSerialize,
-{
-    type Item = &'a mut T;
-    type IntoIter = std::slice::IterMut<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter_mut()
+        let mut data = iter.into_iter().take(N).collect::<Vec<_>>();
+        for _ in data.len()..N {
+            data.push(T::default())
+        }
+        data.try_into().unwrap()
     }
 }
 
@@ -179,11 +252,21 @@ mod tests {
     const COUNT: usize = 32;
 
     #[test]
+    fn test_from_iter() {
+        let data = vec![2u8; 10];
+        let vector = Vector::<u8, 1>::from_iter(data.clone());
+        assert_eq!(vector[0], 2u8);
+
+        let vector = Vector::<u8, 20>::from_iter(data);
+        assert_eq!(vector[..10], [2u8; 10]);
+        assert_eq!(vector[10..], [0u8; 10]);
+    }
+
+    #[test]
     fn encode_vector() {
-        let mut value: Vector<u16, COUNT> = Vector::default();
-        for elem in &mut value {
-            *elem = 33u16;
-        }
+        let data = vec![33u16; COUNT];
+        let mut value = Vector::<u16, COUNT>::try_from(data).unwrap();
+
         value[0] = 34u16;
         assert_eq!(value[0], 34u16);
         value[0] = 33u16;
@@ -204,7 +287,7 @@ mod tests {
             1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8,
         ];
         let result = Vector::<u8, COUNT>::deserialize(&bytes).expect("can deserialize");
-        let expected: Vector<u8, COUNT> = Vector(bytes.try_into().expect("test data"));
+        let expected: Vector<u8, COUNT> = bytes.try_into().expect("test data");
         assert_eq!(result, expected);
     }
 
@@ -216,8 +299,7 @@ mod tests {
             .collect();
         let permutation = &mut inner[3];
         let _ = permutation.pop().expect("test data correct");
-        let input: Vector<List<u8, 1>, COUNT> =
-            Vector(inner.try_into().expect("test data correct"));
+        let input: Vector<List<u8, 1>, COUNT> = inner.try_into().expect("test data correct");
         let mut buffer = vec![];
         let _ = input.serialize(&mut buffer).expect("can serialize");
         let expected = vec![16, 0, 0, 0, 17, 0, 0, 0, 18, 0, 0, 0, 19, 0, 0, 0, 0, 1, 2];
@@ -230,7 +312,7 @@ mod tests {
             0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 0u8,
             1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8,
         ];
-        let input: Vector<u8, COUNT> = Vector(bytes.try_into().expect("test data"));
+        let input: Vector<u8, COUNT> = bytes.try_into().expect("test data");
         let mut buffer = vec![];
         let _ = input.serialize(&mut buffer).expect("can serialize");
         let recovered = Vector::<u8, COUNT>::deserialize(&buffer).expect("can decode");
@@ -245,8 +327,7 @@ mod tests {
             .collect();
         let permutation = &mut inner[3];
         let _ = permutation.pop().expect("test data correct");
-        let input: Vector<List<u8, 1>, COUNT> =
-            Vector(inner.try_into().expect("test data correct"));
+        let input: Vector<List<u8, 1>, COUNT> = inner.try_into().expect("test data correct");
         let mut buffer = vec![];
         let _ = input.serialize(&mut buffer).expect("can serialize");
         let recovered = Vector::<List<u8, 1>, COUNT>::deserialize(&buffer).expect("can decode");

--- a/ssz_rs/tests/basic_vector.rs
+++ b/ssz_rs/tests/basic_vector.rs
@@ -7,7 +7,7 @@ use test_utils::{
 
 #[test]
 fn test_basic_vector_vec_uint256_16_max() {
-    let value = Vector::<U256, 16>::from_iter([
+    let mut value = Vector::<U256, 16>::from_iter([
         U256([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -82,7 +82,7 @@ fn test_basic_vector_vec_uint256_16_max() {
     let recovered_value: Vector<U256, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("006eed26f731a68917853879507d9fa9f4044f7af999f9df535fac29715db555");
     assert_eq!(root, expected_root);
@@ -90,7 +90,7 @@ fn test_basic_vector_vec_uint256_16_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_5_random() {
-    let value = Vector::<u64, 5>::from_iter([
+    let mut value = Vector::<u64, 5>::from_iter([
         5828194763697002133,
         3153164540286514337,
         17780602567657386724,
@@ -106,7 +106,7 @@ fn test_basic_vector_vec_uint64_5_random() {
     let recovered_value: Vector<u64, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("11f1f940a8342239bd6a9f7eb4f08eff81e1d4467df7399a6d8729c59aabb984");
     assert_eq!(root, expected_root);
@@ -114,7 +114,7 @@ fn test_basic_vector_vec_uint64_5_random() {
 
 #[test]
 fn test_basic_vector_vec_uint256_512_zero() {
-    let value = Vector::<U256, 512>::from_iter([
+    let mut value = Vector::<U256, 512>::from_iter([
         U256([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -2173,7 +2173,7 @@ fn test_basic_vector_vec_uint256_512_zero() {
     let recovered_value: Vector<U256, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("506d86582d252405b840018792cad2bf1259f1ef5aa5f887e13cb2f0094f51e1");
     assert_eq!(root, expected_root);
@@ -2181,7 +2181,7 @@ fn test_basic_vector_vec_uint256_512_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_513_zero() {
-    let value = Vector::<u16, 513>::from_iter([
+    let mut value = Vector::<u16, 513>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2210,7 +2210,7 @@ fn test_basic_vector_vec_uint16_513_zero() {
     let recovered_value: Vector<u16, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d88ddfeed400a8755596b21942c1497e114c302e6118290f91e6772976041fa1");
     assert_eq!(root, expected_root);
@@ -2218,7 +2218,7 @@ fn test_basic_vector_vec_uint16_513_zero() {
 
 #[test]
 fn test_basic_vector_vec_bool_4_zero() {
-    let value = Vector::<bool, 4>::from_iter([false, false, false, false]);
+    let mut value = Vector::<bool, 4>::from_iter([false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_4_zero/serialized.ssz_snappy",
@@ -2228,7 +2228,7 @@ fn test_basic_vector_vec_bool_4_zero() {
     let recovered_value: Vector<bool, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2236,7 +2236,7 @@ fn test_basic_vector_vec_bool_4_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint64_5_zero() {
-    let value = Vector::<u64, 5>::from_iter([0, 0, 0, 0, 0]);
+    let mut value = Vector::<u64, 5>::from_iter([0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_5_zero/serialized.ssz_snappy",
@@ -2246,7 +2246,7 @@ fn test_basic_vector_vec_uint64_5_zero() {
     let recovered_value: Vector<u64, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2254,7 +2254,7 @@ fn test_basic_vector_vec_uint64_5_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_1_random() {
-    let value = Vector::<u8, 1>::from_iter([225]);
+    let mut value = Vector::<u8, 1>::from_iter([225]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_1_random/serialized.ssz_snappy",
@@ -2264,7 +2264,7 @@ fn test_basic_vector_vec_uint8_1_random() {
     let recovered_value: Vector<u8, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2272,7 +2272,7 @@ fn test_basic_vector_vec_uint8_1_random() {
 
 #[test]
 fn test_basic_vector_vec_uint32_513_random() {
-    let value = Vector::<u32, 513>::from_iter([
+    let mut value = Vector::<u32, 513>::from_iter([
         1506286316, 3340455671, 2249197219, 1137228810, 3708188369, 1032790960, 2037375995,
         2165993127, 4279139643, 2878934835, 2234060784, 3341241397, 2832291162, 1862974295,
         2889755957, 716023347, 1781425995, 2766618165, 430694095, 1734393401, 3038286926,
@@ -2356,7 +2356,7 @@ fn test_basic_vector_vec_uint32_513_random() {
     let recovered_value: Vector<u32, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("73d6601e80c118fe2d467dcc72a40e9a121608b87b5d1333a6a95fcbc93af038");
     assert_eq!(root, expected_root);
@@ -2364,7 +2364,7 @@ fn test_basic_vector_vec_uint32_513_random() {
 
 #[test]
 fn test_basic_vector_vec_uint32_4_random() {
-    let value = Vector::<u32, 4>::from_iter([2599571881, 2754953818, 2448479820, 3973051506]);
+    let mut value = Vector::<u32, 4>::from_iter([2599571881, 2754953818, 2448479820, 3973051506]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_4_random/serialized.ssz_snappy",
@@ -2374,7 +2374,7 @@ fn test_basic_vector_vec_uint32_4_random() {
     let recovered_value: Vector<u32, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a951f29a5a4235a44cd6f09172f4cfec00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2382,7 +2382,7 @@ fn test_basic_vector_vec_uint32_4_random() {
 
 #[test]
 fn test_basic_vector_vec_bool_31_max() {
-    let value = Vector::<bool, 31>::from_iter([
+    let mut value = Vector::<bool, 31>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true,
@@ -2396,7 +2396,7 @@ fn test_basic_vector_vec_bool_31_max() {
     let recovered_value: Vector<bool, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0101010101010101010101010101010101010101010101010101010101010100");
     assert_eq!(root, expected_root);
@@ -2404,7 +2404,7 @@ fn test_basic_vector_vec_bool_31_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_5_zero() {
-    let value = Vector::<u8, 5>::from_iter([0, 0, 0, 0, 0]);
+    let mut value = Vector::<u8, 5>::from_iter([0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_5_zero/serialized.ssz_snappy",
@@ -2414,7 +2414,7 @@ fn test_basic_vector_vec_uint8_5_zero() {
     let recovered_value: Vector<u8, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2422,7 +2422,7 @@ fn test_basic_vector_vec_uint8_5_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_2_random() {
-    let value = Vector::<u16, 2>::from_iter([12188, 36886]);
+    let mut value = Vector::<u16, 2>::from_iter([12188, 36886]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_2_random/serialized.ssz_snappy",
@@ -2432,7 +2432,7 @@ fn test_basic_vector_vec_uint16_2_random() {
     let recovered_value: Vector<u16, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9c2f169000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2440,7 +2440,7 @@ fn test_basic_vector_vec_uint16_2_random() {
 
 #[test]
 fn test_basic_vector_vec_bool_8_zero() {
-    let value =
+    let mut value =
         Vector::<bool, 8>::from_iter([false, false, false, false, false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2451,7 +2451,7 @@ fn test_basic_vector_vec_bool_8_zero() {
     let recovered_value: Vector<bool, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2459,7 +2459,7 @@ fn test_basic_vector_vec_bool_8_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_16_max() {
-    let value = Vector::<u128, 16>::from_iter([
+    let mut value = Vector::<u128, 16>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -2486,7 +2486,7 @@ fn test_basic_vector_vec_uint128_16_max() {
     let recovered_value: Vector<u128, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("be1b7015ed50d7490a51f1b11dff804a4440775cc808b9cfd26157805c1f8e86");
     assert_eq!(root, expected_root);
@@ -2494,7 +2494,7 @@ fn test_basic_vector_vec_uint128_16_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_8_random() {
-    let value = Vector::<u32, 8>::from_iter([
+    let mut value = Vector::<u32, 8>::from_iter([
         2255247108, 883929842, 2722841916, 3289001244, 3428769191, 4039771928, 1073577161,
         1629830620,
     ]);
@@ -2507,7 +2507,7 @@ fn test_basic_vector_vec_uint32_8_random() {
     let recovered_value: Vector<u32, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("04576c86f2b2af343c454ba21c2d0ac4a7dd5ecc1807caf0c97cfd3fdc3d2561");
     assert_eq!(root, expected_root);
@@ -2515,7 +2515,7 @@ fn test_basic_vector_vec_uint32_8_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_31_max() {
-    let value = Vector::<u64, 31>::from_iter([
+    let mut value = Vector::<u64, 31>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -2557,7 +2557,7 @@ fn test_basic_vector_vec_uint64_31_max() {
     let recovered_value: Vector<u64, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6323465d736a7126b4e2a25da8d76670d49d6bb0cdf9ffc77d0b007a9e86d77c");
     assert_eq!(root, expected_root);
@@ -2565,7 +2565,7 @@ fn test_basic_vector_vec_uint64_31_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_31_random() {
-    let value = Vector::<U256, 31>::from_iter([
+    let mut value = Vector::<U256, 31>::from_iter([
         U256([
             193, 221, 0, 27, 7, 14, 132, 79, 246, 169, 102, 206, 52, 7, 70, 134, 104, 201, 85, 248,
             190, 117, 18, 78, 173, 106, 20, 121, 246, 174, 52, 111,
@@ -2700,7 +2700,7 @@ fn test_basic_vector_vec_uint256_31_random() {
     let recovered_value: Vector<U256, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a1bd4eec44b1f37b07b53f29daf2a3569be0d6ebe727e18539071206950a6813");
     assert_eq!(root, expected_root);
@@ -2708,7 +2708,7 @@ fn test_basic_vector_vec_uint256_31_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_8_zero() {
-    let value = Vector::<u64, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u64, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_8_zero/serialized.ssz_snappy",
@@ -2718,7 +2718,7 @@ fn test_basic_vector_vec_uint64_8_zero() {
     let recovered_value: Vector<u64, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2726,7 +2726,7 @@ fn test_basic_vector_vec_uint64_8_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_512_random() {
-    let value = Vector::<u128, 512>::from_iter([
+    let mut value = Vector::<u128, 512>::from_iter([
         26828682623905485853721589978864387876,
         45362230084934828632880963081896644001,
         247417070223805448009596661148965288679,
@@ -3249,7 +3249,7 @@ fn test_basic_vector_vec_uint128_512_random() {
     let recovered_value: Vector<u128, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a70c5dc4851c46df26580a4d719f454113421b5b078b1af7b8f6435f8d61b304");
     assert_eq!(root, expected_root);
@@ -3257,7 +3257,7 @@ fn test_basic_vector_vec_uint128_512_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_3_random() {
-    let value = Vector::<u8, 3>::from_iter([46, 17, 42]);
+    let mut value = Vector::<u8, 3>::from_iter([46, 17, 42]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_3_random/serialized.ssz_snappy",
@@ -3267,7 +3267,7 @@ fn test_basic_vector_vec_uint8_3_random() {
     let recovered_value: Vector<u8, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2e112a0000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3275,7 +3275,7 @@ fn test_basic_vector_vec_uint8_3_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_4_zero() {
-    let value = Vector::<u8, 4>::from_iter([0, 0, 0, 0]);
+    let mut value = Vector::<u8, 4>::from_iter([0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_4_zero/serialized.ssz_snappy",
@@ -3285,7 +3285,7 @@ fn test_basic_vector_vec_uint8_4_zero() {
     let recovered_value: Vector<u8, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3293,7 +3293,7 @@ fn test_basic_vector_vec_uint8_4_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_2_random() {
-    let value = Vector::<U256, 2>::from_iter([
+    let mut value = Vector::<U256, 2>::from_iter([
         U256([
             205, 105, 106, 166, 152, 194, 84, 202, 219, 225, 56, 160, 68, 10, 149, 101, 132, 138,
             122, 138, 194, 11, 156, 151, 229, 118, 123, 132, 155, 190, 223, 147,
@@ -3312,7 +3312,7 @@ fn test_basic_vector_vec_uint256_2_random() {
     let recovered_value: Vector<U256, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e765c4ca305f07d9e25e1c4c879528e9994b9fb5e4230bfda8c4b7805b1905c7");
     assert_eq!(root, expected_root);
@@ -3320,7 +3320,7 @@ fn test_basic_vector_vec_uint256_2_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_31_random() {
-    let value = Vector::<u8, 31>::from_iter([
+    let mut value = Vector::<u8, 31>::from_iter([
         170, 73, 242, 193, 85, 27, 39, 254, 83, 38, 110, 73, 13, 177, 56, 72, 156, 232, 20, 213,
         141, 20, 90, 139, 79, 153, 79, 237, 21, 197, 178,
     ]);
@@ -3333,7 +3333,7 @@ fn test_basic_vector_vec_uint8_31_random() {
     let recovered_value: Vector<u8, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("aa49f2c1551b27fe53266e490db138489ce814d58d145a8b4f994fed15c5b200");
     assert_eq!(root, expected_root);
@@ -3341,7 +3341,7 @@ fn test_basic_vector_vec_uint8_31_random() {
 
 #[test]
 fn test_basic_vector_vec_uint256_8_max() {
-    let value = Vector::<U256, 8>::from_iter([
+    let mut value = Vector::<U256, 8>::from_iter([
         U256([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -3384,7 +3384,7 @@ fn test_basic_vector_vec_uint256_8_max() {
     let recovered_value: Vector<U256, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("be1b7015ed50d7490a51f1b11dff804a4440775cc808b9cfd26157805c1f8e86");
     assert_eq!(root, expected_root);
@@ -3392,7 +3392,7 @@ fn test_basic_vector_vec_uint256_8_max() {
 
 #[test]
 fn test_basic_vector_vec_uint16_16_random() {
-    let value = Vector::<u16, 16>::from_iter([
+    let mut value = Vector::<u16, 16>::from_iter([
         14966, 37668, 46928, 65487, 22250, 24796, 7043, 49742, 46495, 44245, 5372, 46169, 36046,
         60670, 29615, 59474,
     ]);
@@ -3405,7 +3405,7 @@ fn test_basic_vector_vec_uint16_16_random() {
     let recovered_value: Vector<u16, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("763a249350b7cfffea56dc60831b4ec29fb5d5acfc1459b4ce8cfeecaf7352e8");
     assert_eq!(root, expected_root);
@@ -3413,7 +3413,7 @@ fn test_basic_vector_vec_uint16_16_random() {
 
 #[test]
 fn test_basic_vector_vec_uint32_1_zero() {
-    let value = Vector::<u32, 1>::from_iter([0]);
+    let mut value = Vector::<u32, 1>::from_iter([0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_1_zero/serialized.ssz_snappy",
@@ -3423,7 +3423,7 @@ fn test_basic_vector_vec_uint32_1_zero() {
     let recovered_value: Vector<u32, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3431,7 +3431,7 @@ fn test_basic_vector_vec_uint32_1_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_8_random() {
-    let value = Vector::<u128, 8>::from_iter([
+    let mut value = Vector::<u128, 8>::from_iter([
         50419731819167183509591636238702702250,
         243160052554941226771061620517961416402,
         132077915854571525015052582449039997777,
@@ -3450,7 +3450,7 @@ fn test_basic_vector_vec_uint128_8_random() {
     let recovered_value: Vector<u128, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5b77a9c4d86ba3e9079f98093f5e6da648e81f10f89f46c1fcab2a4c779c0363");
     assert_eq!(root, expected_root);
@@ -3458,7 +3458,7 @@ fn test_basic_vector_vec_uint128_8_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_4_zero() {
-    let value = Vector::<u64, 4>::from_iter([0, 0, 0, 0]);
+    let mut value = Vector::<u64, 4>::from_iter([0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_4_zero/serialized.ssz_snappy",
@@ -3468,7 +3468,7 @@ fn test_basic_vector_vec_uint64_4_zero() {
     let recovered_value: Vector<u64, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3476,7 +3476,7 @@ fn test_basic_vector_vec_uint64_4_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_31_max() {
-    let value = Vector::<u8, 31>::from_iter([
+    let mut value = Vector::<u8, 31>::from_iter([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ]);
@@ -3489,7 +3489,7 @@ fn test_basic_vector_vec_uint8_31_max() {
     let recovered_value: Vector<u8, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00");
     assert_eq!(root, expected_root);
@@ -3497,7 +3497,7 @@ fn test_basic_vector_vec_uint8_31_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_4_random() {
-    let value = Vector::<u128, 4>::from_iter([
+    let mut value = Vector::<u128, 4>::from_iter([
         131085251763681703650210983225134279210,
         204149994827974013891189432256283029251,
         138314451233364434501509339736780133583,
@@ -3512,7 +3512,7 @@ fn test_basic_vector_vec_uint128_4_random() {
     let recovered_value: Vector<u128, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e7b9070421c5a3414fa58f06ad8bdf6f4a8e8464fe1dc5b1214aab2db1662e06");
     assert_eq!(root, expected_root);
@@ -3520,7 +3520,7 @@ fn test_basic_vector_vec_uint128_4_random() {
 
 #[test]
 fn test_basic_vector_vec_bool_5_zero() {
-    let value = Vector::<bool, 5>::from_iter([false, false, false, false, false]);
+    let mut value = Vector::<bool, 5>::from_iter([false, false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_5_zero/serialized.ssz_snappy",
@@ -3530,7 +3530,7 @@ fn test_basic_vector_vec_bool_5_zero() {
     let recovered_value: Vector<bool, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3538,7 +3538,7 @@ fn test_basic_vector_vec_bool_5_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_512_zero() {
-    let value = Vector::<u16, 512>::from_iter([
+    let mut value = Vector::<u16, 512>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3567,7 +3567,7 @@ fn test_basic_vector_vec_uint16_512_zero() {
     let recovered_value: Vector<u16, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30");
     assert_eq!(root, expected_root);
@@ -3575,7 +3575,7 @@ fn test_basic_vector_vec_uint16_512_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_31_zero() {
-    let value = Vector::<u8, 31>::from_iter([
+    let mut value = Vector::<u8, 31>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
     let encoding = serialize(&value);
@@ -3587,7 +3587,7 @@ fn test_basic_vector_vec_uint8_31_zero() {
     let recovered_value: Vector<u8, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3595,7 +3595,7 @@ fn test_basic_vector_vec_uint8_31_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_8_zero() {
-    let value = Vector::<u8, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u8, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_8_zero/serialized.ssz_snappy",
@@ -3605,7 +3605,7 @@ fn test_basic_vector_vec_uint8_8_zero() {
     let recovered_value: Vector<u8, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3613,7 +3613,7 @@ fn test_basic_vector_vec_uint8_8_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_1_zero() {
-    let value = Vector::<u16, 1>::from_iter([0]);
+    let mut value = Vector::<u16, 1>::from_iter([0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_1_zero/serialized.ssz_snappy",
@@ -3623,7 +3623,7 @@ fn test_basic_vector_vec_uint16_1_zero() {
     let recovered_value: Vector<u16, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3631,7 +3631,7 @@ fn test_basic_vector_vec_uint16_1_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_513_zero() {
-    let value = Vector::<U256, 513>::from_iter([
+    let mut value = Vector::<U256, 513>::from_iter([
         U256([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -5694,7 +5694,7 @@ fn test_basic_vector_vec_uint256_513_zero() {
     let recovered_value: Vector<U256, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffff0ad7e659772f9534c195c815efc4014ef1e1daed4404c06385d11192e92b");
     assert_eq!(root, expected_root);
@@ -5702,7 +5702,7 @@ fn test_basic_vector_vec_uint256_513_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_3_max() {
-    let value = Vector::<u16, 3>::from_iter([65535, 65535, 65535]);
+    let mut value = Vector::<u16, 3>::from_iter([65535, 65535, 65535]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_3_max/serialized.ssz_snappy",
@@ -5712,7 +5712,7 @@ fn test_basic_vector_vec_uint16_3_max() {
     let recovered_value: Vector<u16, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffff0000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5720,7 +5720,7 @@ fn test_basic_vector_vec_uint16_3_max() {
 
 #[test]
 fn test_basic_vector_vec_bool_512_zero() {
-    let value = Vector::<bool, 512>::from_iter([
+    let mut value = Vector::<bool, 512>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -5771,7 +5771,7 @@ fn test_basic_vector_vec_bool_512_zero() {
     let recovered_value: Vector<bool, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c");
     assert_eq!(root, expected_root);
@@ -5779,7 +5779,7 @@ fn test_basic_vector_vec_bool_512_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_512_zero() {
-    let value = Vector::<u128, 512>::from_iter([
+    let mut value = Vector::<u128, 512>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -5808,7 +5808,7 @@ fn test_basic_vector_vec_uint128_512_zero() {
     let recovered_value: Vector<u128, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("26846476fd5fc54a5d43385167c95144f2643f533cc85bb9d16b782f8d7db193");
     assert_eq!(root, expected_root);
@@ -5816,7 +5816,7 @@ fn test_basic_vector_vec_uint128_512_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint64_8_max() {
-    let value = Vector::<u64, 8>::from_iter([
+    let mut value = Vector::<u64, 8>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -5835,7 +5835,7 @@ fn test_basic_vector_vec_uint64_8_max() {
     let recovered_value: Vector<u64, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -5843,7 +5843,7 @@ fn test_basic_vector_vec_uint64_8_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_2_max() {
-    let value = Vector::<u32, 2>::from_iter([4294967295, 4294967295]);
+    let mut value = Vector::<u32, 2>::from_iter([4294967295, 4294967295]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_2_max/serialized.ssz_snappy",
@@ -5853,7 +5853,7 @@ fn test_basic_vector_vec_uint32_2_max() {
     let recovered_value: Vector<u32, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5861,7 +5861,7 @@ fn test_basic_vector_vec_uint32_2_max() {
 
 #[test]
 fn test_basic_vector_vec_uint16_4_random() {
-    let value = Vector::<u16, 4>::from_iter([15417, 28067, 51352, 59311]);
+    let mut value = Vector::<u16, 4>::from_iter([15417, 28067, 51352, 59311]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_4_random/serialized.ssz_snappy",
@@ -5871,7 +5871,7 @@ fn test_basic_vector_vec_uint16_4_random() {
     let recovered_value: Vector<u16, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("393ca36d98c8afe7000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5879,7 +5879,7 @@ fn test_basic_vector_vec_uint16_4_random() {
 
 #[test]
 fn test_basic_vector_vec_uint32_2_random() {
-    let value = Vector::<u32, 2>::from_iter([2286406229, 3289673013]);
+    let mut value = Vector::<u32, 2>::from_iter([2286406229, 3289673013]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_2_random/serialized.ssz_snappy",
@@ -5889,7 +5889,7 @@ fn test_basic_vector_vec_uint32_2_random() {
     let recovered_value: Vector<u32, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("55ca4788356d14c4000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5897,7 +5897,7 @@ fn test_basic_vector_vec_uint32_2_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_513_random() {
-    let value = Vector::<u16, 513>::from_iter([
+    let mut value = Vector::<u16, 513>::from_iter([
         27185, 40496, 45588, 22785, 5755, 5950, 14234, 16151, 23366, 48189, 28838, 47431, 22937,
         44687, 9960, 18008, 43796, 16472, 40344, 6307, 60750, 42176, 48076, 3047, 34291, 53364,
         5934, 35808, 39627, 16700, 61818, 17790, 2074, 12801, 14876, 34651, 31986, 54424, 35627,
@@ -5948,7 +5948,7 @@ fn test_basic_vector_vec_uint16_513_random() {
     let recovered_value: Vector<u16, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("188c519f6d8f57d2cc1232b7ad085ed707cec9537fb3912ffa095423dc614dea");
     assert_eq!(root, expected_root);
@@ -5956,7 +5956,7 @@ fn test_basic_vector_vec_uint16_513_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_8_random() {
-    let value =
+    let mut value =
         Vector::<u16, 8>::from_iter([48757, 12920, 33149, 59406, 48754, 39786, 12312, 58318]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -5967,7 +5967,7 @@ fn test_basic_vector_vec_uint16_8_random() {
     let recovered_value: Vector<u16, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("75be78327d810ee872be6a9b1830cee300000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5975,7 +5975,7 @@ fn test_basic_vector_vec_uint16_8_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_16_zero() {
-    let value = Vector::<u8, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u8, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_16_zero/serialized.ssz_snappy",
@@ -5985,7 +5985,7 @@ fn test_basic_vector_vec_uint8_16_zero() {
     let recovered_value: Vector<u8, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5993,7 +5993,7 @@ fn test_basic_vector_vec_uint8_16_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_3_zero() {
-    let value = Vector::<u8, 3>::from_iter([0, 0, 0]);
+    let mut value = Vector::<u8, 3>::from_iter([0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_3_zero/serialized.ssz_snappy",
@@ -6003,7 +6003,7 @@ fn test_basic_vector_vec_uint8_3_zero() {
     let recovered_value: Vector<u8, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6011,7 +6011,7 @@ fn test_basic_vector_vec_uint8_3_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint32_3_max() {
-    let value = Vector::<u32, 3>::from_iter([4294967295, 4294967295, 4294967295]);
+    let mut value = Vector::<u32, 3>::from_iter([4294967295, 4294967295, 4294967295]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_3_max/serialized.ssz_snappy",
@@ -6021,7 +6021,7 @@ fn test_basic_vector_vec_uint32_3_max() {
     let recovered_value: Vector<u32, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffff0000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6029,7 +6029,7 @@ fn test_basic_vector_vec_uint32_3_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_1_zero() {
-    let value = Vector::<u128, 1>::from_iter([0]);
+    let mut value = Vector::<u128, 1>::from_iter([0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint128_1_zero/serialized.ssz_snappy",
@@ -6039,7 +6039,7 @@ fn test_basic_vector_vec_uint128_1_zero() {
     let recovered_value: Vector<u128, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6047,7 +6047,7 @@ fn test_basic_vector_vec_uint128_1_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_2_max() {
-    let value = Vector::<u16, 2>::from_iter([65535, 65535]);
+    let mut value = Vector::<u16, 2>::from_iter([65535, 65535]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_2_max/serialized.ssz_snappy",
@@ -6057,7 +6057,7 @@ fn test_basic_vector_vec_uint16_2_max() {
     let recovered_value: Vector<u16, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6065,7 +6065,7 @@ fn test_basic_vector_vec_uint16_2_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_1_max() {
-    let value = Vector::<u32, 1>::from_iter([4294967295]);
+    let mut value = Vector::<u32, 1>::from_iter([4294967295]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_1_max/serialized.ssz_snappy",
@@ -6075,7 +6075,7 @@ fn test_basic_vector_vec_uint32_1_max() {
     let recovered_value: Vector<u32, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6083,7 +6083,7 @@ fn test_basic_vector_vec_uint32_1_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_513_zero() {
-    let value = Vector::<u32, 513>::from_iter([
+    let mut value = Vector::<u32, 513>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -6112,7 +6112,7 @@ fn test_basic_vector_vec_uint32_513_zero() {
     let recovered_value: Vector<u32, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c");
     assert_eq!(root, expected_root);
@@ -6120,7 +6120,7 @@ fn test_basic_vector_vec_uint32_513_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_1_zero() {
-    let value = Vector::<U256, 1>::from_iter([U256([
+    let mut value = Vector::<U256, 1>::from_iter([U256([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ])]);
@@ -6133,7 +6133,7 @@ fn test_basic_vector_vec_uint256_1_zero() {
     let recovered_value: Vector<U256, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6141,7 +6141,7 @@ fn test_basic_vector_vec_uint256_1_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_16_random() {
-    let value = Vector::<u128, 16>::from_iter([
+    let mut value = Vector::<u128, 16>::from_iter([
         116865446011030976513736559583719158568,
         108209157078503776199170871747996541938,
         87702234582352091614673494037436374999,
@@ -6168,7 +6168,7 @@ fn test_basic_vector_vec_uint128_16_random() {
     let recovered_value: Vector<u128, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("817667c88413a5134f4f42a1d0eb8e128cb658f3b2c3956360d32ca62f287f3f");
     assert_eq!(root, expected_root);
@@ -6176,7 +6176,7 @@ fn test_basic_vector_vec_uint128_16_random() {
 
 #[test]
 fn test_basic_vector_vec_bool_2_zero() {
-    let value = Vector::<bool, 2>::from_iter([false, false]);
+    let mut value = Vector::<bool, 2>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_2_zero/serialized.ssz_snappy",
@@ -6186,7 +6186,7 @@ fn test_basic_vector_vec_bool_2_zero() {
     let recovered_value: Vector<bool, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6194,7 +6194,7 @@ fn test_basic_vector_vec_bool_2_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_8_max() {
-    let value = Vector::<u128, 8>::from_iter([
+    let mut value = Vector::<u128, 8>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -6213,7 +6213,7 @@ fn test_basic_vector_vec_uint128_8_max() {
     let recovered_value: Vector<u128, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("375d6c7b280a1e30f968db1d948da0f977bf9139b0d5516761ac874700208aba");
     assert_eq!(root, expected_root);
@@ -6221,7 +6221,7 @@ fn test_basic_vector_vec_uint128_8_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_3_zero() {
-    let value = Vector::<u64, 3>::from_iter([0, 0, 0]);
+    let mut value = Vector::<u64, 3>::from_iter([0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_3_zero/serialized.ssz_snappy",
@@ -6231,7 +6231,7 @@ fn test_basic_vector_vec_uint64_3_zero() {
     let recovered_value: Vector<u64, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6239,7 +6239,7 @@ fn test_basic_vector_vec_uint64_3_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint64_3_random() {
-    let value = Vector::<u64, 3>::from_iter([
+    let mut value = Vector::<u64, 3>::from_iter([
         6167802979638570618,
         1670982671822494120,
         2649190588485934153,
@@ -6253,7 +6253,7 @@ fn test_basic_vector_vec_uint64_3_random() {
     let recovered_value: Vector<u64, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7aeef3ad21709855a819d003e3853017491c03e1cdd0c3240000000000000000");
     assert_eq!(root, expected_root);
@@ -6261,7 +6261,7 @@ fn test_basic_vector_vec_uint64_3_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_1_max() {
-    let value = Vector::<u16, 1>::from_iter([65535]);
+    let mut value = Vector::<u16, 1>::from_iter([65535]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_1_max/serialized.ssz_snappy",
@@ -6271,7 +6271,7 @@ fn test_basic_vector_vec_uint16_1_max() {
     let recovered_value: Vector<u16, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6279,7 +6279,7 @@ fn test_basic_vector_vec_uint16_1_max() {
 
 #[test]
 fn test_basic_vector_vec_bool_8_max() {
-    let value = Vector::<bool, 8>::from_iter([true, true, true, true, true, true, true, true]);
+    let mut value = Vector::<bool, 8>::from_iter([true, true, true, true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_8_max/serialized.ssz_snappy",
@@ -6289,7 +6289,7 @@ fn test_basic_vector_vec_bool_8_max() {
     let recovered_value: Vector<bool, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0101010101010101000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6297,7 +6297,7 @@ fn test_basic_vector_vec_bool_8_max() {
 
 #[test]
 fn test_basic_vector_vec_uint16_5_max() {
-    let value = Vector::<u16, 5>::from_iter([65535, 65535, 65535, 65535, 65535]);
+    let mut value = Vector::<u16, 5>::from_iter([65535, 65535, 65535, 65535, 65535]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_5_max/serialized.ssz_snappy",
@@ -6307,7 +6307,7 @@ fn test_basic_vector_vec_uint16_5_max() {
     let recovered_value: Vector<u16, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffff00000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6315,7 +6315,7 @@ fn test_basic_vector_vec_uint16_5_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_16_max() {
-    let value = Vector::<u32, 16>::from_iter([
+    let mut value = Vector::<u32, 16>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295,
@@ -6329,7 +6329,7 @@ fn test_basic_vector_vec_uint32_16_max() {
     let recovered_value: Vector<u32, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -6337,7 +6337,7 @@ fn test_basic_vector_vec_uint32_16_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_4_max() {
-    let value = Vector::<u32, 4>::from_iter([4294967295, 4294967295, 4294967295, 4294967295]);
+    let mut value = Vector::<u32, 4>::from_iter([4294967295, 4294967295, 4294967295, 4294967295]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_4_max/serialized.ssz_snappy",
@@ -6347,7 +6347,7 @@ fn test_basic_vector_vec_uint32_4_max() {
     let recovered_value: Vector<u32, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6355,7 +6355,7 @@ fn test_basic_vector_vec_uint32_4_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_2_zero() {
-    let value = Vector::<u64, 2>::from_iter([0, 0]);
+    let mut value = Vector::<u64, 2>::from_iter([0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_2_zero/serialized.ssz_snappy",
@@ -6365,7 +6365,7 @@ fn test_basic_vector_vec_uint64_2_zero() {
     let recovered_value: Vector<u64, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6373,7 +6373,7 @@ fn test_basic_vector_vec_uint64_2_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_512_random() {
-    let value = Vector::<u8, 512>::from_iter([
+    let mut value = Vector::<u8, 512>::from_iter([
         253, 174, 239, 243, 23, 241, 87, 225, 224, 151, 140, 63, 95, 213, 223, 61, 52, 248, 192,
         130, 98, 176, 55, 80, 137, 79, 165, 228, 36, 40, 202, 109, 24, 146, 19, 112, 44, 162, 156,
         235, 33, 131, 37, 218, 103, 51, 203, 99, 235, 120, 184, 105, 215, 89, 104, 154, 30, 180,
@@ -6411,7 +6411,7 @@ fn test_basic_vector_vec_uint8_512_random() {
     let recovered_value: Vector<u8, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f4eb96b6673f096fe9ac07abad28b1ae70eeaf6704326b183ed57a02e22933e4");
     assert_eq!(root, expected_root);
@@ -6419,7 +6419,7 @@ fn test_basic_vector_vec_uint8_512_random() {
 
 #[test]
 fn test_basic_vector_vec_uint32_31_random() {
-    let value = Vector::<u32, 31>::from_iter([
+    let mut value = Vector::<u32, 31>::from_iter([
         508235682, 2308341395, 1525766118, 4136650562, 3621852454, 1567937308, 3269584467,
         1320546218, 2077416840, 739946730, 1282600407, 3203298029, 942979653, 497143087, 933745505,
         3794525861, 2714083317, 1289423485, 3524519556, 3497991789, 3711737680, 3061871525,
@@ -6435,7 +6435,7 @@ fn test_basic_vector_vec_uint32_31_random() {
     let recovered_value: Vector<u32, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("efa45b70c8a45a482800655c239ed2e8d91d1325666fd1755da23b6fea1405ee");
     assert_eq!(root, expected_root);
@@ -6443,7 +6443,7 @@ fn test_basic_vector_vec_uint32_31_random() {
 
 #[test]
 fn test_basic_vector_vec_bool_3_zero() {
-    let value = Vector::<bool, 3>::from_iter([false, false, false]);
+    let mut value = Vector::<bool, 3>::from_iter([false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_3_zero/serialized.ssz_snappy",
@@ -6453,7 +6453,7 @@ fn test_basic_vector_vec_bool_3_zero() {
     let recovered_value: Vector<bool, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6461,7 +6461,7 @@ fn test_basic_vector_vec_bool_3_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint64_512_random() {
-    let value = Vector::<u64, 512>::from_iter([
+    let mut value = Vector::<u64, 512>::from_iter([
         17241722399186003656,
         4508348299491693172,
         6390266777275510888,
@@ -6984,7 +6984,7 @@ fn test_basic_vector_vec_uint64_512_random() {
     let recovered_value: Vector<u64, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0dac791ef3e531baa9195787060367a1ea72df21153ceff38d53d67bdbf14cdb");
     assert_eq!(root, expected_root);
@@ -6992,7 +6992,7 @@ fn test_basic_vector_vec_uint64_512_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_16_max() {
-    let value = Vector::<u16, 16>::from_iter([
+    let mut value = Vector::<u16, 16>::from_iter([
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535,
     ]);
@@ -7005,7 +7005,7 @@ fn test_basic_vector_vec_uint16_16_max() {
     let recovered_value: Vector<u16, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -7013,7 +7013,7 @@ fn test_basic_vector_vec_uint16_16_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_1_random() {
-    let value = Vector::<u64, 1>::from_iter([8914067055681793591]);
+    let mut value = Vector::<u64, 1>::from_iter([8914067055681793591]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_1_random/serialized.ssz_snappy",
@@ -7023,7 +7023,7 @@ fn test_basic_vector_vec_uint64_1_random() {
     let recovered_value: Vector<u64, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("37eeec25c220b57b000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7031,7 +7031,7 @@ fn test_basic_vector_vec_uint64_1_random() {
 
 #[test]
 fn test_basic_vector_vec_uint32_512_zero() {
-    let value = Vector::<u32, 512>::from_iter([
+    let mut value = Vector::<u32, 512>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -7060,7 +7060,7 @@ fn test_basic_vector_vec_uint32_512_zero() {
     let recovered_value: Vector<u32, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d88ddfeed400a8755596b21942c1497e114c302e6118290f91e6772976041fa1");
     assert_eq!(root, expected_root);
@@ -7068,7 +7068,7 @@ fn test_basic_vector_vec_uint32_512_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint32_5_max() {
-    let value =
+    let mut value =
         Vector::<u32, 5>::from_iter([4294967295, 4294967295, 4294967295, 4294967295, 4294967295]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -7079,7 +7079,7 @@ fn test_basic_vector_vec_uint32_5_max() {
     let recovered_value: Vector<u32, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffff000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7087,7 +7087,7 @@ fn test_basic_vector_vec_uint32_5_max() {
 
 #[test]
 fn test_basic_vector_vec_uint16_4_max() {
-    let value = Vector::<u16, 4>::from_iter([65535, 65535, 65535, 65535]);
+    let mut value = Vector::<u16, 4>::from_iter([65535, 65535, 65535, 65535]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_4_max/serialized.ssz_snappy",
@@ -7097,7 +7097,7 @@ fn test_basic_vector_vec_uint16_4_max() {
     let recovered_value: Vector<u16, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7105,7 +7105,7 @@ fn test_basic_vector_vec_uint16_4_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_2_random() {
-    let value = Vector::<u128, 2>::from_iter([
+    let mut value = Vector::<u128, 2>::from_iter([
         293619838168840684930947284175392625045,
         264388153583386100657556026933098957077,
     ]);
@@ -7118,7 +7118,7 @@ fn test_basic_vector_vec_uint128_2_random() {
     let recovered_value: Vector<u128, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9551683c41029561557e6e42b51fe5dc15c90da19169c5900b46e5a5624ee7c6");
     assert_eq!(root, expected_root);
@@ -7126,7 +7126,7 @@ fn test_basic_vector_vec_uint128_2_random() {
 
 #[test]
 fn test_basic_vector_vec_uint256_4_random() {
-    let value = Vector::<U256, 4>::from_iter([
+    let mut value = Vector::<U256, 4>::from_iter([
         U256([
             71, 106, 105, 163, 151, 75, 86, 137, 3, 140, 57, 168, 63, 49, 156, 118, 90, 171, 234,
             173, 47, 5, 84, 194, 65, 72, 161, 55, 197, 219, 55, 187,
@@ -7153,7 +7153,7 @@ fn test_basic_vector_vec_uint256_4_random() {
     let recovered_value: Vector<U256, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fa6875722e5f598b45c4b742d1156f397f73e5aeb1a6bb33eed523bdba40693d");
     assert_eq!(root, expected_root);
@@ -7161,7 +7161,7 @@ fn test_basic_vector_vec_uint256_4_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_513_max() {
-    let value = Vector::<u8, 513>::from_iter([
+    let mut value = Vector::<u8, 513>::from_iter([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -7201,7 +7201,7 @@ fn test_basic_vector_vec_uint8_513_max() {
     let recovered_value: Vector<u8, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("711318b44d37a71b616d0747647acbe4b8cd24d42a19c6a3ed7b8743adc33bd4");
     assert_eq!(root, expected_root);
@@ -7209,7 +7209,7 @@ fn test_basic_vector_vec_uint8_513_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_8_random() {
-    let value = Vector::<U256, 8>::from_iter([
+    let mut value = Vector::<U256, 8>::from_iter([
         U256([
             101, 98, 195, 77, 141, 84, 10, 65, 199, 185, 225, 176, 137, 102, 31, 27, 37, 157, 156,
             98, 26, 68, 252, 14, 97, 110, 55, 40, 121, 83, 119, 1,
@@ -7252,7 +7252,7 @@ fn test_basic_vector_vec_uint256_8_random() {
     let recovered_value: Vector<U256, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f37250ebb8bfc70f992eb9c95107ea4def905c0062cda51a2688641a19645505");
     assert_eq!(root, expected_root);
@@ -7260,7 +7260,7 @@ fn test_basic_vector_vec_uint256_8_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_2_zero() {
-    let value = Vector::<u8, 2>::from_iter([0, 0]);
+    let mut value = Vector::<u8, 2>::from_iter([0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_2_zero/serialized.ssz_snappy",
@@ -7270,7 +7270,7 @@ fn test_basic_vector_vec_uint8_2_zero() {
     let recovered_value: Vector<u8, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7278,7 +7278,7 @@ fn test_basic_vector_vec_uint8_2_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_513_random() {
-    let value = Vector::<U256, 513>::from_iter([
+    let mut value = Vector::<U256, 513>::from_iter([
         U256([
             178, 71, 197, 209, 59, 6, 21, 36, 228, 31, 161, 186, 233, 29, 46, 37, 73, 216, 72, 86,
             69, 54, 206, 110, 221, 177, 166, 166, 186, 186, 215, 68,
@@ -9341,7 +9341,7 @@ fn test_basic_vector_vec_uint256_513_random() {
     let recovered_value: Vector<U256, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cf114fb32b16706fc55188ad17f4dcced660baf4f31353048a5f51317134dc2b");
     assert_eq!(root, expected_root);
@@ -9349,7 +9349,7 @@ fn test_basic_vector_vec_uint256_513_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_31_random() {
-    let value = Vector::<u64, 31>::from_iter([
+    let mut value = Vector::<u64, 31>::from_iter([
         3052724393868548387,
         3810693530679841654,
         12585541796688525245,
@@ -9391,7 +9391,7 @@ fn test_basic_vector_vec_uint64_31_random() {
     let recovered_value: Vector<u64, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("692da28053f3e2d585e5359989519e2af9044140b7f50d0db8e36b89e5ddd6f3");
     assert_eq!(root, expected_root);
@@ -9399,7 +9399,7 @@ fn test_basic_vector_vec_uint64_31_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_512_max() {
-    let value = Vector::<u8, 512>::from_iter([
+    let mut value = Vector::<u8, 512>::from_iter([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -9439,7 +9439,7 @@ fn test_basic_vector_vec_uint8_512_max() {
     let recovered_value: Vector<u8, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("006eed26f731a68917853879507d9fa9f4044f7af999f9df535fac29715db555");
     assert_eq!(root, expected_root);
@@ -9447,7 +9447,7 @@ fn test_basic_vector_vec_uint8_512_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_8_max() {
-    let value = Vector::<u8, 8>::from_iter([255, 255, 255, 255, 255, 255, 255, 255]);
+    let mut value = Vector::<u8, 8>::from_iter([255, 255, 255, 255, 255, 255, 255, 255]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_8_max/serialized.ssz_snappy",
@@ -9457,7 +9457,7 @@ fn test_basic_vector_vec_uint8_8_max() {
     let recovered_value: Vector<u8, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9465,7 +9465,7 @@ fn test_basic_vector_vec_uint8_8_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_5_random() {
-    let value = Vector::<u8, 5>::from_iter([15, 8, 177, 247, 237]);
+    let mut value = Vector::<u8, 5>::from_iter([15, 8, 177, 247, 237]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_5_random/serialized.ssz_snappy",
@@ -9475,7 +9475,7 @@ fn test_basic_vector_vec_uint8_5_random() {
     let recovered_value: Vector<u8, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0f08b1f7ed000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9483,7 +9483,7 @@ fn test_basic_vector_vec_uint8_5_random() {
 
 #[test]
 fn test_basic_vector_vec_bool_513_zero() {
-    let value = Vector::<bool, 513>::from_iter([
+    let mut value = Vector::<bool, 513>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -9534,7 +9534,7 @@ fn test_basic_vector_vec_bool_513_zero() {
     let recovered_value: Vector<bool, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30");
     assert_eq!(root, expected_root);
@@ -9542,7 +9542,7 @@ fn test_basic_vector_vec_bool_513_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_513_zero() {
-    let value = Vector::<u128, 513>::from_iter([
+    let mut value = Vector::<u128, 513>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -9571,7 +9571,7 @@ fn test_basic_vector_vec_uint128_513_zero() {
     let recovered_value: Vector<u128, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("506d86582d252405b840018792cad2bf1259f1ef5aa5f887e13cb2f0094f51e1");
     assert_eq!(root, expected_root);
@@ -9579,7 +9579,7 @@ fn test_basic_vector_vec_uint128_513_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_3_zero() {
-    let value = Vector::<u128, 3>::from_iter([0, 0, 0]);
+    let mut value = Vector::<u128, 3>::from_iter([0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint128_3_zero/serialized.ssz_snappy",
@@ -9589,7 +9589,7 @@ fn test_basic_vector_vec_uint128_3_zero() {
     let recovered_value: Vector<u128, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -9597,7 +9597,7 @@ fn test_basic_vector_vec_uint128_3_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint32_8_zero() {
-    let value = Vector::<u32, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u32, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_8_zero/serialized.ssz_snappy",
@@ -9607,7 +9607,7 @@ fn test_basic_vector_vec_uint32_8_zero() {
     let recovered_value: Vector<u32, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9615,7 +9615,7 @@ fn test_basic_vector_vec_uint32_8_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_5_max() {
-    let value = Vector::<u8, 5>::from_iter([255, 255, 255, 255, 255]);
+    let mut value = Vector::<u8, 5>::from_iter([255, 255, 255, 255, 255]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_5_max/serialized.ssz_snappy",
@@ -9625,7 +9625,7 @@ fn test_basic_vector_vec_uint8_5_max() {
     let recovered_value: Vector<u8, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffff000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9633,7 +9633,7 @@ fn test_basic_vector_vec_uint8_5_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_31_max() {
-    let value = Vector::<u32, 31>::from_iter([
+    let mut value = Vector::<u32, 31>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
@@ -9649,7 +9649,7 @@ fn test_basic_vector_vec_uint32_31_max() {
     let recovered_value: Vector<u32, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e7492e2fb875c43b137514ed057ddfc23ddd1220431403c9a3395e2bbaf51407");
     assert_eq!(root, expected_root);
@@ -9657,7 +9657,7 @@ fn test_basic_vector_vec_uint32_31_max() {
 
 #[test]
 fn test_basic_vector_vec_uint16_3_random() {
-    let value = Vector::<u16, 3>::from_iter([55998, 58650, 32471]);
+    let mut value = Vector::<u16, 3>::from_iter([55998, 58650, 32471]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_3_random/serialized.ssz_snappy",
@@ -9667,7 +9667,7 @@ fn test_basic_vector_vec_uint16_3_random() {
     let recovered_value: Vector<u16, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("beda1ae5d77e0000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9675,7 +9675,7 @@ fn test_basic_vector_vec_uint16_3_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_1_max() {
-    let value = Vector::<u64, 1>::from_iter([18446744073709551615]);
+    let mut value = Vector::<u64, 1>::from_iter([18446744073709551615]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_1_max/serialized.ssz_snappy",
@@ -9685,7 +9685,7 @@ fn test_basic_vector_vec_uint64_1_max() {
     let recovered_value: Vector<u64, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9693,7 +9693,7 @@ fn test_basic_vector_vec_uint64_1_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_3_max() {
-    let value = Vector::<u128, 3>::from_iter([
+    let mut value = Vector::<u128, 3>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -9707,7 +9707,7 @@ fn test_basic_vector_vec_uint128_3_max() {
     let recovered_value: Vector<u128, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1e3915ef9ca4ed8619d472b72fb1833448756054b4de9acb439da54dff7166aa");
     assert_eq!(root, expected_root);
@@ -9715,7 +9715,7 @@ fn test_basic_vector_vec_uint128_3_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_5_random() {
-    let value =
+    let mut value =
         Vector::<u32, 5>::from_iter([1051503312, 1875702585, 3338068896, 1062162289, 44280150]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -9726,7 +9726,7 @@ fn test_basic_vector_vec_uint32_5_random() {
     let recovered_value: Vector<u32, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d0aaac3e39f3cc6fa0e3f6c6714f4f3f56a9a302000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9734,7 +9734,7 @@ fn test_basic_vector_vec_uint32_5_random() {
 
 #[test]
 fn test_basic_vector_vec_uint256_1_random() {
-    let value = Vector::<U256, 1>::from_iter([U256([
+    let mut value = Vector::<U256, 1>::from_iter([U256([
         23, 198, 217, 240, 65, 96, 243, 95, 206, 232, 214, 26, 230, 80, 25, 35, 116, 138, 185, 248,
         165, 147, 63, 252, 41, 25, 209, 95, 73, 233, 26, 244,
     ])]);
@@ -9747,7 +9747,7 @@ fn test_basic_vector_vec_uint256_1_random() {
     let recovered_value: Vector<U256, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("17c6d9f04160f35fcee8d61ae6501923748ab9f8a5933ffc2919d15f49e91af4");
     assert_eq!(root, expected_root);
@@ -9755,7 +9755,7 @@ fn test_basic_vector_vec_uint256_1_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_1_zero() {
-    let value = Vector::<u8, 1>::from_iter([0]);
+    let mut value = Vector::<u8, 1>::from_iter([0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_1_zero/serialized.ssz_snappy",
@@ -9765,7 +9765,7 @@ fn test_basic_vector_vec_uint8_1_zero() {
     let recovered_value: Vector<u8, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9773,7 +9773,7 @@ fn test_basic_vector_vec_uint8_1_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_16_zero() {
-    let value = Vector::<u128, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u128, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint128_16_zero/serialized.ssz_snappy",
@@ -9783,7 +9783,7 @@ fn test_basic_vector_vec_uint128_16_zero() {
     let recovered_value: Vector<u128, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c");
     assert_eq!(root, expected_root);
@@ -9791,7 +9791,7 @@ fn test_basic_vector_vec_uint128_16_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_16_random() {
-    let value = Vector::<U256, 16>::from_iter([
+    let mut value = Vector::<U256, 16>::from_iter([
         U256([
             240, 52, 157, 62, 33, 82, 186, 76, 43, 156, 161, 241, 59, 31, 225, 79, 247, 97, 118,
             251, 234, 138, 47, 120, 129, 122, 206, 216, 201, 221, 67, 133,
@@ -9866,7 +9866,7 @@ fn test_basic_vector_vec_uint256_16_random() {
     let recovered_value: Vector<U256, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1acf6f6a33e7a6642bf9f60d5c829ca9f09390bf30663f50ef1424796f582057");
     assert_eq!(root, expected_root);
@@ -9874,7 +9874,7 @@ fn test_basic_vector_vec_uint256_16_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_31_random() {
-    let value = Vector::<u16, 31>::from_iter([
+    let mut value = Vector::<u16, 31>::from_iter([
         2630, 4376, 65427, 13583, 41975, 15842, 27686, 33957, 45114, 56180, 24895, 4175, 40381,
         32830, 48421, 52207, 58611, 41821, 31373, 23853, 55119, 1957, 34877, 62496, 37311, 40303,
         44876, 36839, 47492, 53209, 24055,
@@ -9888,7 +9888,7 @@ fn test_basic_vector_vec_uint16_31_random() {
     let recovered_value: Vector<u16, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("29fab6cb24858519d6e8d3af2fdac7ec9fce5c08e978fb1a3cdb3fad6fe88f7f");
     assert_eq!(root, expected_root);
@@ -9896,7 +9896,7 @@ fn test_basic_vector_vec_uint16_31_random() {
 
 #[test]
 fn test_basic_vector_vec_uint32_512_random() {
-    let value = Vector::<u32, 512>::from_iter([
+    let mut value = Vector::<u32, 512>::from_iter([
         3535294352, 2244578171, 32943704, 3015817426, 2456157102, 219351158, 2006999311,
         1996972550, 2838712831, 1656769757, 3318502982, 4213769932, 2050078503, 4292367497,
         4290313471, 1262779699, 4083724714, 1323361645, 974092343, 710698434, 2984936844,
@@ -9979,7 +9979,7 @@ fn test_basic_vector_vec_uint32_512_random() {
     let recovered_value: Vector<u32, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("29520e549f20e52e3cd8ef74509a65c936a54c25207355c6c7d8b93b50c16b79");
     assert_eq!(root, expected_root);
@@ -9987,7 +9987,7 @@ fn test_basic_vector_vec_uint32_512_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_8_zero() {
-    let value = Vector::<u16, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u16, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_8_zero/serialized.ssz_snappy",
@@ -9997,7 +9997,7 @@ fn test_basic_vector_vec_uint16_8_zero() {
     let recovered_value: Vector<u16, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -10005,7 +10005,7 @@ fn test_basic_vector_vec_uint16_8_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_31_max() {
-    let value = Vector::<u16, 31>::from_iter([
+    let mut value = Vector::<u16, 31>::from_iter([
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535,
@@ -10019,7 +10019,7 @@ fn test_basic_vector_vec_uint16_31_max() {
     let recovered_value: Vector<u16, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("43cbd26c37dcff8448ce8896f9b5e553a1047de0c59ec3b477decefbdea9c74b");
     assert_eq!(root, expected_root);
@@ -10027,7 +10027,7 @@ fn test_basic_vector_vec_uint16_31_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_2_max() {
-    let value = Vector::<u128, 2>::from_iter([
+    let mut value = Vector::<u128, 2>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
     ]);
@@ -10040,7 +10040,7 @@ fn test_basic_vector_vec_uint128_2_max() {
     let recovered_value: Vector<u128, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -10048,7 +10048,7 @@ fn test_basic_vector_vec_uint128_2_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_4_max() {
-    let value = Vector::<u8, 4>::from_iter([255, 255, 255, 255]);
+    let mut value = Vector::<u8, 4>::from_iter([255, 255, 255, 255]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_4_max/serialized.ssz_snappy",
@@ -10058,7 +10058,7 @@ fn test_basic_vector_vec_uint8_4_max() {
     let recovered_value: Vector<u8, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -10066,7 +10066,7 @@ fn test_basic_vector_vec_uint8_4_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_16_random() {
-    let value = Vector::<u8, 16>::from_iter([
+    let mut value = Vector::<u8, 16>::from_iter([
         238, 35, 45, 23, 138, 32, 154, 246, 181, 136, 127, 102, 232, 9, 36, 2,
     ]);
     let encoding = serialize(&value);
@@ -10078,7 +10078,7 @@ fn test_basic_vector_vec_uint8_16_random() {
     let recovered_value: Vector<u8, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ee232d178a209af6b5887f66e809240200000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -10086,7 +10086,7 @@ fn test_basic_vector_vec_uint8_16_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_512_zero() {
-    let value = Vector::<u8, 512>::from_iter([
+    let mut value = Vector::<u8, 512>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -10115,7 +10115,7 @@ fn test_basic_vector_vec_uint8_512_zero() {
     let recovered_value: Vector<u8, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c");
     assert_eq!(root, expected_root);
@@ -10123,7 +10123,7 @@ fn test_basic_vector_vec_uint8_512_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint32_4_zero() {
-    let value = Vector::<u32, 4>::from_iter([0, 0, 0, 0]);
+    let mut value = Vector::<u32, 4>::from_iter([0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_4_zero/serialized.ssz_snappy",
@@ -10133,7 +10133,7 @@ fn test_basic_vector_vec_uint32_4_zero() {
     let recovered_value: Vector<u32, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -10141,7 +10141,7 @@ fn test_basic_vector_vec_uint32_4_zero() {
 
 #[test]
 fn test_basic_vector_vec_bool_4_max() {
-    let value = Vector::<bool, 4>::from_iter([true, true, true, true]);
+    let mut value = Vector::<bool, 4>::from_iter([true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_4_max/serialized.ssz_snappy",
@@ -10151,7 +10151,7 @@ fn test_basic_vector_vec_bool_4_max() {
     let recovered_value: Vector<bool, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0101010100000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -10159,7 +10159,7 @@ fn test_basic_vector_vec_bool_4_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_513_max() {
-    let value = Vector::<u32, 513>::from_iter([
+    let mut value = Vector::<u32, 513>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
@@ -10244,7 +10244,7 @@ fn test_basic_vector_vec_uint32_513_max() {
     let recovered_value: Vector<u32, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e243d140ab8d341e3cad517d2ba8cd3b8ef7df2ff6f6962f0aeaf20e366fe7e3");
     assert_eq!(root, expected_root);
@@ -10252,7 +10252,7 @@ fn test_basic_vector_vec_uint32_513_max() {
 
 #[test]
 fn test_basic_vector_vec_bool_513_max() {
-    let value = Vector::<bool, 513>::from_iter([
+    let mut value = Vector::<bool, 513>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -10298,7 +10298,7 @@ fn test_basic_vector_vec_bool_513_max() {
     let recovered_value: Vector<bool, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5299a985b414f61b75a2c8c15f886b14a1a668135c01d9a44f094b893d72852");
     assert_eq!(root, expected_root);
@@ -10306,7 +10306,7 @@ fn test_basic_vector_vec_bool_513_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_1_zero() {
-    let value = Vector::<u64, 1>::from_iter([0]);
+    let mut value = Vector::<u64, 1>::from_iter([0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_1_zero/serialized.ssz_snappy",
@@ -10316,7 +10316,7 @@ fn test_basic_vector_vec_uint64_1_zero() {
     let recovered_value: Vector<u64, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -10324,7 +10324,7 @@ fn test_basic_vector_vec_uint64_1_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint64_2_max() {
-    let value = Vector::<u64, 2>::from_iter([18446744073709551615, 18446744073709551615]);
+    let mut value = Vector::<u64, 2>::from_iter([18446744073709551615, 18446744073709551615]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_2_max/serialized.ssz_snappy",
@@ -10334,7 +10334,7 @@ fn test_basic_vector_vec_uint64_2_max() {
     let recovered_value: Vector<u64, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -10342,7 +10342,7 @@ fn test_basic_vector_vec_uint64_2_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_8_max() {
-    let value = Vector::<u32, 8>::from_iter([
+    let mut value = Vector::<u32, 8>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295,
     ]);
@@ -10355,7 +10355,7 @@ fn test_basic_vector_vec_uint32_8_max() {
     let recovered_value: Vector<u32, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -10363,7 +10363,7 @@ fn test_basic_vector_vec_uint32_8_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_513_max() {
-    let value = Vector::<U256, 513>::from_iter([
+    let mut value = Vector::<U256, 513>::from_iter([
         U256([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -12426,7 +12426,7 @@ fn test_basic_vector_vec_uint256_513_max() {
     let recovered_value: Vector<U256, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8d90ae08c4b61479f6867707545ea8b26e91d9ef54e863a8daf7427f1e4d04c1");
     assert_eq!(root, expected_root);
@@ -12434,7 +12434,7 @@ fn test_basic_vector_vec_uint256_513_max() {
 
 #[test]
 fn test_basic_vector_vec_uint16_4_zero() {
-    let value = Vector::<u16, 4>::from_iter([0, 0, 0, 0]);
+    let mut value = Vector::<u16, 4>::from_iter([0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_4_zero/serialized.ssz_snappy",
@@ -12444,7 +12444,7 @@ fn test_basic_vector_vec_uint16_4_zero() {
     let recovered_value: Vector<u16, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -12452,7 +12452,7 @@ fn test_basic_vector_vec_uint16_4_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_512_max() {
-    let value = Vector::<U256, 512>::from_iter([
+    let mut value = Vector::<U256, 512>::from_iter([
         U256([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -14511,7 +14511,7 @@ fn test_basic_vector_vec_uint256_512_max() {
     let recovered_value: Vector<U256, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a278cf32ca74f920b67a7b3d02447453d8883fecb4a7aa1ba4327079fa3d5162");
     assert_eq!(root, expected_root);
@@ -14519,7 +14519,7 @@ fn test_basic_vector_vec_uint256_512_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_8_random() {
-    let value = Vector::<u64, 8>::from_iter([
+    let mut value = Vector::<u64, 8>::from_iter([
         598083651574187315,
         16261093746939895763,
         11288686854153899408,
@@ -14538,7 +14538,7 @@ fn test_basic_vector_vec_uint64_8_random() {
     let recovered_value: Vector<u64, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d5a3754afc2badf65538d7358ba6199e5433893701dafc2f775e6e3b49cf13ca");
     assert_eq!(root, expected_root);
@@ -14546,7 +14546,7 @@ fn test_basic_vector_vec_uint64_8_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_4_random() {
-    let value = Vector::<u64, 4>::from_iter([
+    let mut value = Vector::<u64, 4>::from_iter([
         7900660817174063737,
         6533979385570669156,
         4271747397033668748,
@@ -14561,7 +14561,7 @@ fn test_basic_vector_vec_uint64_4_random() {
     let recovered_value: Vector<u64, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("79ea815a27c9a46d6432aaf6a15bad5a8c3064fa9f4b483bda4bf4888173cf30");
     assert_eq!(root, expected_root);
@@ -14569,7 +14569,7 @@ fn test_basic_vector_vec_uint64_4_random() {
 
 #[test]
 fn test_basic_vector_vec_uint128_1_max() {
-    let value = Vector::<u128, 1>::from_iter([340282366920938463463374607431768211455]);
+    let mut value = Vector::<u128, 1>::from_iter([340282366920938463463374607431768211455]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint128_1_max/serialized.ssz_snappy",
@@ -14579,7 +14579,7 @@ fn test_basic_vector_vec_uint128_1_max() {
     let recovered_value: Vector<u128, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -14587,7 +14587,7 @@ fn test_basic_vector_vec_uint128_1_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_3_max() {
-    let value = Vector::<u64, 3>::from_iter([
+    let mut value = Vector::<u64, 3>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -14601,7 +14601,7 @@ fn test_basic_vector_vec_uint64_3_max() {
     let recovered_value: Vector<u64, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000");
     assert_eq!(root, expected_root);
@@ -14609,7 +14609,7 @@ fn test_basic_vector_vec_uint64_3_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_3_zero() {
-    let value = Vector::<U256, 3>::from_iter([
+    let mut value = Vector::<U256, 3>::from_iter([
         U256([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -14632,7 +14632,7 @@ fn test_basic_vector_vec_uint256_3_zero() {
     let recovered_value: Vector<U256, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -14640,7 +14640,7 @@ fn test_basic_vector_vec_uint256_3_zero() {
 
 #[test]
 fn test_basic_vector_vec_bool_512_max() {
-    let value = Vector::<bool, 512>::from_iter([
+    let mut value = Vector::<bool, 512>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -14686,7 +14686,7 @@ fn test_basic_vector_vec_bool_512_max() {
     let recovered_value: Vector<bool, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("bea533dbcce99238f8e459b813178182fbb2903627d119e0e6a91718dee93bec");
     assert_eq!(root, expected_root);
@@ -14694,7 +14694,7 @@ fn test_basic_vector_vec_bool_512_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_512_max() {
-    let value = Vector::<u32, 512>::from_iter([
+    let mut value = Vector::<u32, 512>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
@@ -14779,7 +14779,7 @@ fn test_basic_vector_vec_uint32_512_max() {
     let recovered_value: Vector<u32, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7c09b1cdfe9a7e172dfe2ca8715becf5132c036abbfdfb500daa9c51f365074d");
     assert_eq!(root, expected_root);
@@ -14787,7 +14787,7 @@ fn test_basic_vector_vec_uint32_512_max() {
 
 #[test]
 fn test_basic_vector_vec_uint16_8_max() {
-    let value =
+    let mut value =
         Vector::<u16, 8>::from_iter([65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -14798,7 +14798,7 @@ fn test_basic_vector_vec_uint16_8_max() {
     let recovered_value: Vector<u16, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -14806,7 +14806,7 @@ fn test_basic_vector_vec_uint16_8_max() {
 
 #[test]
 fn test_basic_vector_vec_bool_5_max() {
-    let value = Vector::<bool, 5>::from_iter([true, true, true, true, true]);
+    let mut value = Vector::<bool, 5>::from_iter([true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_5_max/serialized.ssz_snappy",
@@ -14816,7 +14816,7 @@ fn test_basic_vector_vec_bool_5_max() {
     let recovered_value: Vector<bool, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0101010101000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -14824,7 +14824,7 @@ fn test_basic_vector_vec_bool_5_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_16_zero() {
-    let value = Vector::<U256, 16>::from_iter([
+    let mut value = Vector::<U256, 16>::from_iter([
         U256([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -14899,7 +14899,7 @@ fn test_basic_vector_vec_uint256_16_zero() {
     let recovered_value: Vector<U256, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c");
     assert_eq!(root, expected_root);
@@ -14907,7 +14907,7 @@ fn test_basic_vector_vec_uint256_16_zero() {
 
 #[test]
 fn test_basic_vector_vec_bool_1_max() {
-    let value = Vector::<bool, 1>::from_iter([true]);
+    let mut value = Vector::<bool, 1>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_1_max/serialized.ssz_snappy",
@@ -14917,7 +14917,7 @@ fn test_basic_vector_vec_bool_1_max() {
     let recovered_value: Vector<bool, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -14925,7 +14925,7 @@ fn test_basic_vector_vec_bool_1_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_5_max() {
-    let value = Vector::<u128, 5>::from_iter([
+    let mut value = Vector::<u128, 5>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -14941,7 +14941,7 @@ fn test_basic_vector_vec_uint128_5_max() {
     let recovered_value: Vector<u128, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("42b2994e8f77b7cc4b05fe01a2d6570ab7d29be54e434582425697ee8cd8f2c2");
     assert_eq!(root, expected_root);
@@ -14949,7 +14949,7 @@ fn test_basic_vector_vec_uint128_5_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_3_max() {
-    let value = Vector::<u8, 3>::from_iter([255, 255, 255]);
+    let mut value = Vector::<u8, 3>::from_iter([255, 255, 255]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_3_max/serialized.ssz_snappy",
@@ -14959,7 +14959,7 @@ fn test_basic_vector_vec_uint8_3_max() {
     let recovered_value: Vector<u8, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffff0000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -14967,7 +14967,7 @@ fn test_basic_vector_vec_uint8_3_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_2_zero() {
-    let value = Vector::<U256, 2>::from_iter([
+    let mut value = Vector::<U256, 2>::from_iter([
         U256([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -14986,7 +14986,7 @@ fn test_basic_vector_vec_uint256_2_zero() {
     let recovered_value: Vector<U256, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -14994,7 +14994,7 @@ fn test_basic_vector_vec_uint256_2_zero() {
 
 #[test]
 fn test_basic_vector_vec_bool_16_zero() {
-    let value = Vector::<bool, 16>::from_iter([
+    let mut value = Vector::<bool, 16>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false,
     ]);
@@ -15007,7 +15007,7 @@ fn test_basic_vector_vec_bool_16_zero() {
     let recovered_value: Vector<bool, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15015,7 +15015,7 @@ fn test_basic_vector_vec_bool_16_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint32_16_zero() {
-    let value = Vector::<u32, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u32, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_16_zero/serialized.ssz_snappy",
@@ -15025,7 +15025,7 @@ fn test_basic_vector_vec_uint32_16_zero() {
     let recovered_value: Vector<u32, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -15033,7 +15033,7 @@ fn test_basic_vector_vec_uint32_16_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_5_zero() {
-    let value = Vector::<u16, 5>::from_iter([0, 0, 0, 0, 0]);
+    let mut value = Vector::<u16, 5>::from_iter([0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_5_zero/serialized.ssz_snappy",
@@ -15043,7 +15043,7 @@ fn test_basic_vector_vec_uint16_5_zero() {
     let recovered_value: Vector<u16, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15051,7 +15051,7 @@ fn test_basic_vector_vec_uint16_5_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint64_31_zero() {
-    let value = Vector::<u64, 31>::from_iter([
+    let mut value = Vector::<u64, 31>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
     let encoding = serialize(&value);
@@ -15063,7 +15063,7 @@ fn test_basic_vector_vec_uint64_31_zero() {
     let recovered_value: Vector<u64, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c");
     assert_eq!(root, expected_root);
@@ -15071,7 +15071,7 @@ fn test_basic_vector_vec_uint64_31_zero() {
 
 #[test]
 fn test_basic_vector_vec_bool_1_zero() {
-    let value = Vector::<bool, 1>::from_iter([false]);
+    let mut value = Vector::<bool, 1>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_1_zero/serialized.ssz_snappy",
@@ -15081,7 +15081,7 @@ fn test_basic_vector_vec_bool_1_zero() {
     let recovered_value: Vector<bool, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15089,7 +15089,7 @@ fn test_basic_vector_vec_bool_1_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_2_max() {
-    let value = Vector::<u8, 2>::from_iter([255, 255]);
+    let mut value = Vector::<u8, 2>::from_iter([255, 255]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_2_max/serialized.ssz_snappy",
@@ -15099,7 +15099,7 @@ fn test_basic_vector_vec_uint8_2_max() {
     let recovered_value: Vector<u8, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15107,7 +15107,7 @@ fn test_basic_vector_vec_uint8_2_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_4_max() {
-    let value = Vector::<u128, 4>::from_iter([
+    let mut value = Vector::<u128, 4>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -15122,7 +15122,7 @@ fn test_basic_vector_vec_uint128_4_max() {
     let recovered_value: Vector<u128, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -15130,7 +15130,7 @@ fn test_basic_vector_vec_uint128_4_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_513_zero() {
-    let value = Vector::<u8, 513>::from_iter([
+    let mut value = Vector::<u8, 513>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -15159,7 +15159,7 @@ fn test_basic_vector_vec_uint8_513_zero() {
     let recovered_value: Vector<u8, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30");
     assert_eq!(root, expected_root);
@@ -15167,7 +15167,7 @@ fn test_basic_vector_vec_uint8_513_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint32_5_zero() {
-    let value = Vector::<u32, 5>::from_iter([0, 0, 0, 0, 0]);
+    let mut value = Vector::<u32, 5>::from_iter([0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_5_zero/serialized.ssz_snappy",
@@ -15177,7 +15177,7 @@ fn test_basic_vector_vec_uint32_5_zero() {
     let recovered_value: Vector<u32, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15185,7 +15185,7 @@ fn test_basic_vector_vec_uint32_5_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_31_zero() {
-    let value = Vector::<u16, 31>::from_iter([
+    let mut value = Vector::<u16, 31>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
     let encoding = serialize(&value);
@@ -15197,7 +15197,7 @@ fn test_basic_vector_vec_uint16_31_zero() {
     let recovered_value: Vector<u16, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -15205,7 +15205,7 @@ fn test_basic_vector_vec_uint16_31_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_5_random() {
-    let value = Vector::<u128, 5>::from_iter([
+    let mut value = Vector::<u128, 5>::from_iter([
         194578830033788736352569855138204668708,
         222404791245710801707639009374583541271,
         300921627290141104382250227469409620613,
@@ -15221,7 +15221,7 @@ fn test_basic_vector_vec_uint128_5_random() {
     let recovered_value: Vector<u128, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3783f4ecb6a705af305039d2f104b57616a40fd279144e6723358ca561a22a51");
     assert_eq!(root, expected_root);
@@ -15229,7 +15229,7 @@ fn test_basic_vector_vec_uint128_5_random() {
 
 #[test]
 fn test_basic_vector_vec_bool_2_max() {
-    let value = Vector::<bool, 2>::from_iter([true, true]);
+    let mut value = Vector::<bool, 2>::from_iter([true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_2_max/serialized.ssz_snappy",
@@ -15239,7 +15239,7 @@ fn test_basic_vector_vec_bool_2_max() {
     let recovered_value: Vector<bool, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0101000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15247,7 +15247,7 @@ fn test_basic_vector_vec_bool_2_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_513_max() {
-    let value = Vector::<u128, 513>::from_iter([
+    let mut value = Vector::<u128, 513>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -15771,7 +15771,7 @@ fn test_basic_vector_vec_uint128_513_max() {
     let recovered_value: Vector<u128, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("71b09f3b6e5e978c55a3e8e88640e9abbfe68c41e61e96424cffa42b63bfa413");
     assert_eq!(root, expected_root);
@@ -15779,7 +15779,7 @@ fn test_basic_vector_vec_uint128_513_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_4_max() {
-    let value = Vector::<u64, 4>::from_iter([
+    let mut value = Vector::<u64, 4>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -15794,7 +15794,7 @@ fn test_basic_vector_vec_uint64_4_max() {
     let recovered_value: Vector<u64, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -15802,7 +15802,7 @@ fn test_basic_vector_vec_uint64_4_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_3_random() {
-    let value = Vector::<U256, 3>::from_iter([
+    let mut value = Vector::<U256, 3>::from_iter([
         U256([
             180, 21, 110, 11, 140, 206, 247, 50, 116, 42, 151, 240, 95, 129, 184, 145, 10, 60, 171,
             40, 120, 79, 137, 163, 69, 100, 70, 1, 173, 244, 248, 44,
@@ -15825,7 +15825,7 @@ fn test_basic_vector_vec_uint256_3_random() {
     let recovered_value: Vector<U256, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0d0ad5da1149666a95382488e4164f5eaf34c9a5d4616dabaf74fc5c1cb5416c");
     assert_eq!(root, expected_root);
@@ -15833,7 +15833,7 @@ fn test_basic_vector_vec_uint256_3_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_1_random() {
-    let value = Vector::<u16, 1>::from_iter([58671]);
+    let mut value = Vector::<u16, 1>::from_iter([58671]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_1_random/serialized.ssz_snappy",
@@ -15843,7 +15843,7 @@ fn test_basic_vector_vec_uint16_1_random() {
     let recovered_value: Vector<u16, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2fe5000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15851,7 +15851,7 @@ fn test_basic_vector_vec_uint16_1_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_5_max() {
-    let value = Vector::<u64, 5>::from_iter([
+    let mut value = Vector::<u64, 5>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -15867,7 +15867,7 @@ fn test_basic_vector_vec_uint64_5_max() {
     let recovered_value: Vector<u64, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f0b46c4ab8cd5720de9457addeff0a7267e475c09fd5abb6661e32faf9dd30cd");
     assert_eq!(root, expected_root);
@@ -15875,7 +15875,7 @@ fn test_basic_vector_vec_uint64_5_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_1_max() {
-    let value = Vector::<u8, 1>::from_iter([255]);
+    let mut value = Vector::<u8, 1>::from_iter([255]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_1_max/serialized.ssz_snappy",
@@ -15885,7 +15885,7 @@ fn test_basic_vector_vec_uint8_1_max() {
     let recovered_value: Vector<u8, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15893,7 +15893,7 @@ fn test_basic_vector_vec_uint8_1_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_513_random() {
-    let value = Vector::<u128, 513>::from_iter([
+    let mut value = Vector::<u128, 513>::from_iter([
         34806233895606943316594477386264063388,
         269482665842274191832954812547223680643,
         98566888497380199723262118438348948905,
@@ -16417,7 +16417,7 @@ fn test_basic_vector_vec_uint128_513_random() {
     let recovered_value: Vector<u128, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7c9e8b3a007dbdcf573b837b5ace3e186a390e605306d95a3c9c4fc893b62088");
     assert_eq!(root, expected_root);
@@ -16425,7 +16425,7 @@ fn test_basic_vector_vec_uint128_513_random() {
 
 #[test]
 fn test_basic_vector_vec_uint8_2_random() {
-    let value = Vector::<u8, 2>::from_iter([59, 3]);
+    let mut value = Vector::<u8, 2>::from_iter([59, 3]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_2_random/serialized.ssz_snappy",
@@ -16435,7 +16435,7 @@ fn test_basic_vector_vec_uint8_2_random() {
     let recovered_value: Vector<u8, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3b03000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16443,7 +16443,7 @@ fn test_basic_vector_vec_uint8_2_random() {
 
 #[test]
 fn test_basic_vector_vec_uint128_512_max() {
-    let value = Vector::<u128, 512>::from_iter([
+    let mut value = Vector::<u128, 512>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -16966,7 +16966,7 @@ fn test_basic_vector_vec_uint128_512_max() {
     let recovered_value: Vector<u128, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d13fb49c7c7e17c33d7bfb88c3e3d674e602b53315c769a4b9f053ffba656cc3");
     assert_eq!(root, expected_root);
@@ -16974,7 +16974,7 @@ fn test_basic_vector_vec_uint128_512_max() {
 
 #[test]
 fn test_basic_vector_vec_bool_3_max() {
-    let value = Vector::<bool, 3>::from_iter([true, true, true]);
+    let mut value = Vector::<bool, 3>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_bool_3_max/serialized.ssz_snappy",
@@ -16984,7 +16984,7 @@ fn test_basic_vector_vec_bool_3_max() {
     let recovered_value: Vector<bool, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0101010000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16992,7 +16992,7 @@ fn test_basic_vector_vec_bool_3_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_2_zero() {
-    let value = Vector::<u128, 2>::from_iter([0, 0]);
+    let mut value = Vector::<u128, 2>::from_iter([0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint128_2_zero/serialized.ssz_snappy",
@@ -17002,7 +17002,7 @@ fn test_basic_vector_vec_uint128_2_zero() {
     let recovered_value: Vector<u128, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17010,7 +17010,7 @@ fn test_basic_vector_vec_uint128_2_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint32_2_zero() {
-    let value = Vector::<u32, 2>::from_iter([0, 0]);
+    let mut value = Vector::<u32, 2>::from_iter([0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_2_zero/serialized.ssz_snappy",
@@ -17020,7 +17020,7 @@ fn test_basic_vector_vec_uint32_2_zero() {
     let recovered_value: Vector<u32, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17028,7 +17028,7 @@ fn test_basic_vector_vec_uint32_2_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint64_16_max() {
-    let value = Vector::<u64, 16>::from_iter([
+    let mut value = Vector::<u64, 16>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -17055,7 +17055,7 @@ fn test_basic_vector_vec_uint64_16_max() {
     let recovered_value: Vector<u64, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("375d6c7b280a1e30f968db1d948da0f977bf9139b0d5516761ac874700208aba");
     assert_eq!(root, expected_root);
@@ -17063,7 +17063,7 @@ fn test_basic_vector_vec_uint64_16_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_1_random() {
-    let value = Vector::<u128, 1>::from_iter([209794508200186098054846448654859096491]);
+    let mut value = Vector::<u128, 1>::from_iter([209794508200186098054846448654859096491]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint128_1_random/serialized.ssz_snappy",
@@ -17073,7 +17073,7 @@ fn test_basic_vector_vec_uint128_1_random() {
     let recovered_value: Vector<u128, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("abd1d3e35caaf8d7c91f1b63daf3d49d00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17081,7 +17081,7 @@ fn test_basic_vector_vec_uint128_1_random() {
 
 #[test]
 fn test_basic_vector_vec_uint32_16_random() {
-    let value = Vector::<u32, 16>::from_iter([
+    let mut value = Vector::<u32, 16>::from_iter([
         1381494992, 3456058494, 3316673465, 2895863808, 3039979229, 2658482247, 324065072,
         1118337861, 3690875953, 98201721, 1227056475, 2365715743, 1634445540, 616917765,
         1742195761, 2632010539,
@@ -17095,7 +17095,7 @@ fn test_basic_vector_vec_uint32_16_random() {
     let recovered_value: Vector<u32, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("83aab501333050d1fbd420a889c52af0f2c274a1e4529a5c287b805ed477ccf6");
     assert_eq!(root, expected_root);
@@ -17103,7 +17103,7 @@ fn test_basic_vector_vec_uint32_16_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_2_random() {
-    let value = Vector::<u64, 2>::from_iter([16527226978582771838, 7558561043290308816]);
+    let mut value = Vector::<u64, 2>::from_iter([16527226978582771838, 7558561043290308816]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_2_random/serialized.ssz_snappy",
@@ -17113,7 +17113,7 @@ fn test_basic_vector_vec_uint64_2_random() {
     let recovered_value: Vector<u64, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7eb8ad3c5f815ce5d0c06cce3867e56800000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17121,7 +17121,7 @@ fn test_basic_vector_vec_uint64_2_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_2_zero() {
-    let value = Vector::<u16, 2>::from_iter([0, 0]);
+    let mut value = Vector::<u16, 2>::from_iter([0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_2_zero/serialized.ssz_snappy",
@@ -17131,7 +17131,7 @@ fn test_basic_vector_vec_uint16_2_zero() {
     let recovered_value: Vector<u16, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17139,7 +17139,7 @@ fn test_basic_vector_vec_uint16_2_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_5_zero() {
-    let value = Vector::<U256, 5>::from_iter([
+    let mut value = Vector::<U256, 5>::from_iter([
         U256([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -17170,7 +17170,7 @@ fn test_basic_vector_vec_uint256_5_zero() {
     let recovered_value: Vector<U256, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c");
     assert_eq!(root, expected_root);
@@ -17178,7 +17178,7 @@ fn test_basic_vector_vec_uint256_5_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_5_zero() {
-    let value = Vector::<u128, 5>::from_iter([0, 0, 0, 0, 0]);
+    let mut value = Vector::<u128, 5>::from_iter([0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint128_5_zero/serialized.ssz_snappy",
@@ -17188,7 +17188,7 @@ fn test_basic_vector_vec_uint128_5_zero() {
     let recovered_value: Vector<u128, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -17196,7 +17196,7 @@ fn test_basic_vector_vec_uint128_5_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_31_zero() {
-    let value = Vector::<U256, 31>::from_iter([
+    let mut value = Vector::<U256, 31>::from_iter([
         U256([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -17331,7 +17331,7 @@ fn test_basic_vector_vec_uint256_31_zero() {
     let recovered_value: Vector<U256, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30");
     assert_eq!(root, expected_root);
@@ -17339,7 +17339,7 @@ fn test_basic_vector_vec_uint256_31_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_16_max() {
-    let value = Vector::<u8, 16>::from_iter([
+    let mut value = Vector::<u8, 16>::from_iter([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ]);
     let encoding = serialize(&value);
@@ -17351,7 +17351,7 @@ fn test_basic_vector_vec_uint8_16_max() {
     let recovered_value: Vector<u8, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17359,7 +17359,7 @@ fn test_basic_vector_vec_uint8_16_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_5_max() {
-    let value = Vector::<U256, 5>::from_iter([
+    let mut value = Vector::<U256, 5>::from_iter([
         U256([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -17390,7 +17390,7 @@ fn test_basic_vector_vec_uint256_5_max() {
     let recovered_value: Vector<U256, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8a70016e9e63b5927d8575c08b19132107772e149f3d1ba4e1b4306dce9b7aa5");
     assert_eq!(root, expected_root);
@@ -17398,7 +17398,7 @@ fn test_basic_vector_vec_uint256_5_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_31_zero() {
-    let value = Vector::<u32, 31>::from_iter([
+    let mut value = Vector::<u32, 31>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
     let encoding = serialize(&value);
@@ -17410,7 +17410,7 @@ fn test_basic_vector_vec_uint32_31_zero() {
     let recovered_value: Vector<u32, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -17418,7 +17418,7 @@ fn test_basic_vector_vec_uint32_31_zero() {
 
 #[test]
 fn test_basic_vector_vec_bool_31_zero() {
-    let value = Vector::<bool, 31>::from_iter([
+    let mut value = Vector::<bool, 31>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false,
@@ -17432,7 +17432,7 @@ fn test_basic_vector_vec_bool_31_zero() {
     let recovered_value: Vector<bool, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17440,7 +17440,7 @@ fn test_basic_vector_vec_bool_31_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint64_513_zero() {
-    let value = Vector::<u64, 513>::from_iter([
+    let mut value = Vector::<u64, 513>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -17469,7 +17469,7 @@ fn test_basic_vector_vec_uint64_513_zero() {
     let recovered_value: Vector<u64, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("26846476fd5fc54a5d43385167c95144f2643f533cc85bb9d16b782f8d7db193");
     assert_eq!(root, expected_root);
@@ -17477,7 +17477,7 @@ fn test_basic_vector_vec_uint64_513_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint32_3_random() {
-    let value = Vector::<u32, 3>::from_iter([414721764, 1396444802, 4099449558]);
+    let mut value = Vector::<u32, 3>::from_iter([414721764, 1396444802, 4099449558]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_3_random/serialized.ssz_snappy",
@@ -17487,7 +17487,7 @@ fn test_basic_vector_vec_uint32_3_random() {
     let recovered_value: Vector<u32, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e426b818820e3c53d6a258f40000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17495,7 +17495,7 @@ fn test_basic_vector_vec_uint32_3_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_5_random() {
-    let value = Vector::<u16, 5>::from_iter([35919, 34593, 14706, 39574, 53868]);
+    let mut value = Vector::<u16, 5>::from_iter([35919, 34593, 14706, 39574, 53868]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_5_random/serialized.ssz_snappy",
@@ -17505,7 +17505,7 @@ fn test_basic_vector_vec_uint16_5_random() {
     let recovered_value: Vector<u16, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4f8c21877239969a6cd200000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17513,7 +17513,7 @@ fn test_basic_vector_vec_uint16_5_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_16_random() {
-    let value = Vector::<u64, 16>::from_iter([
+    let mut value = Vector::<u64, 16>::from_iter([
         14973315493487554254,
         14609512114016110986,
         10032323568597029119,
@@ -17540,7 +17540,7 @@ fn test_basic_vector_vec_uint64_16_random() {
     let recovered_value: Vector<u64, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("18efd70dfb660ebe73c72c6f8d0258f97495b3bf86a98741e3c9bfb2aeab5d28");
     assert_eq!(root, expected_root);
@@ -17548,7 +17548,7 @@ fn test_basic_vector_vec_uint64_16_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_16_zero() {
-    let value = Vector::<u64, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u64, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint64_16_zero/serialized.ssz_snappy",
@@ -17558,7 +17558,7 @@ fn test_basic_vector_vec_uint64_16_zero() {
     let recovered_value: Vector<u64, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -17566,7 +17566,7 @@ fn test_basic_vector_vec_uint64_16_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_4_max() {
-    let value = Vector::<U256, 4>::from_iter([
+    let mut value = Vector::<U256, 4>::from_iter([
         U256([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -17593,7 +17593,7 @@ fn test_basic_vector_vec_uint256_4_max() {
     let recovered_value: Vector<U256, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("375d6c7b280a1e30f968db1d948da0f977bf9139b0d5516761ac874700208aba");
     assert_eq!(root, expected_root);
@@ -17601,7 +17601,7 @@ fn test_basic_vector_vec_uint256_4_max() {
 
 #[test]
 fn test_basic_vector_vec_uint16_16_zero() {
-    let value = Vector::<u16, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u16, 16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_16_zero/serialized.ssz_snappy",
@@ -17611,7 +17611,7 @@ fn test_basic_vector_vec_uint16_16_zero() {
     let recovered_value: Vector<u16, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17619,7 +17619,7 @@ fn test_basic_vector_vec_uint16_16_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_512_random() {
-    let value = Vector::<u16, 512>::from_iter([
+    let mut value = Vector::<u16, 512>::from_iter([
         39340, 21094, 12815, 18079, 3546, 9133, 45047, 41320, 3878, 13753, 38525, 64568, 43355,
         62649, 55650, 30889, 7989, 16810, 53928, 52810, 54272, 34111, 43130, 14634, 55804, 24247,
         2549, 37573, 53039, 1273, 63106, 10081, 35901, 22063, 65529, 36398, 22557, 6548, 49942,
@@ -17670,7 +17670,7 @@ fn test_basic_vector_vec_uint16_512_random() {
     let recovered_value: Vector<u16, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("01f2508b1eb51699811c789fd266764f6c2831cbbfd862c91b860066149970e9");
     assert_eq!(root, expected_root);
@@ -17678,7 +17678,7 @@ fn test_basic_vector_vec_uint16_512_random() {
 
 #[test]
 fn test_basic_vector_vec_uint256_31_max() {
-    let value = Vector::<U256, 31>::from_iter([
+    let mut value = Vector::<U256, 31>::from_iter([
         U256([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -17813,7 +17813,7 @@ fn test_basic_vector_vec_uint256_31_max() {
     let recovered_value: Vector<U256, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7399c0e47ac1d2d1e38e8ee039ef6242bd17bc41816dd9c49d0c7720687950df");
     assert_eq!(root, expected_root);
@@ -17821,7 +17821,7 @@ fn test_basic_vector_vec_uint256_31_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_512_random() {
-    let value = Vector::<U256, 512>::from_iter([
+    let mut value = Vector::<U256, 512>::from_iter([
         U256([
             139, 35, 218, 181, 245, 36, 123, 0, 134, 153, 41, 134, 218, 150, 141, 38, 149, 194,
             111, 25, 214, 237, 163, 176, 43, 132, 142, 30, 4, 87, 68, 59,
@@ -19880,7 +19880,7 @@ fn test_basic_vector_vec_uint256_512_random() {
     let recovered_value: Vector<U256, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("88320d2bead34a47f2ef4e1e8e415b42bcb9955ad04e06ff309d49681c2628f2");
     assert_eq!(root, expected_root);
@@ -19888,7 +19888,7 @@ fn test_basic_vector_vec_uint256_512_random() {
 
 #[test]
 fn test_basic_vector_vec_uint256_8_zero() {
-    let value = Vector::<U256, 8>::from_iter([
+    let mut value = Vector::<U256, 8>::from_iter([
         U256([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -19931,7 +19931,7 @@ fn test_basic_vector_vec_uint256_8_zero() {
     let recovered_value: Vector<U256, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c");
     assert_eq!(root, expected_root);
@@ -19939,7 +19939,7 @@ fn test_basic_vector_vec_uint256_8_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint64_512_max() {
-    let value = Vector::<u64, 512>::from_iter([
+    let mut value = Vector::<u64, 512>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -20462,7 +20462,7 @@ fn test_basic_vector_vec_uint64_512_max() {
     let recovered_value: Vector<u64, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8f711e9197bcd96314b8d20425eac7dce4aee7c9a0579e901d636d3256db3672");
     assert_eq!(root, expected_root);
@@ -20470,7 +20470,7 @@ fn test_basic_vector_vec_uint64_512_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_8_random() {
-    let value = Vector::<u8, 8>::from_iter([76, 46, 93, 58, 7, 249, 127, 33]);
+    let mut value = Vector::<u8, 8>::from_iter([76, 46, 93, 58, 7, 249, 127, 33]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_8_random/serialized.ssz_snappy",
@@ -20480,7 +20480,7 @@ fn test_basic_vector_vec_uint8_8_random() {
     let recovered_value: Vector<u8, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4c2e5d3a07f97f21000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -20488,7 +20488,7 @@ fn test_basic_vector_vec_uint8_8_random() {
 
 #[test]
 fn test_basic_vector_vec_uint16_512_max() {
-    let value = Vector::<u16, 512>::from_iter([
+    let mut value = Vector::<u16, 512>::from_iter([
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -20539,7 +20539,7 @@ fn test_basic_vector_vec_uint16_512_max() {
     let recovered_value: Vector<u16, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d3313908d702519e871c34a2b5f7d84108966149289a16d7795ef15ebaa42b25");
     assert_eq!(root, expected_root);
@@ -20547,7 +20547,7 @@ fn test_basic_vector_vec_uint16_512_max() {
 
 #[test]
 fn test_basic_vector_vec_uint8_4_random() {
-    let value = Vector::<u8, 4>::from_iter([50, 181, 121, 8]);
+    let mut value = Vector::<u8, 4>::from_iter([50, 181, 121, 8]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint8_4_random/serialized.ssz_snappy",
@@ -20557,7 +20557,7 @@ fn test_basic_vector_vec_uint8_4_random() {
     let recovered_value: Vector<u8, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("32b5790800000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -20565,7 +20565,7 @@ fn test_basic_vector_vec_uint8_4_random() {
 
 #[test]
 fn test_basic_vector_vec_uint64_512_zero() {
-    let value = Vector::<u64, 512>::from_iter([
+    let mut value = Vector::<u64, 512>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20594,7 +20594,7 @@ fn test_basic_vector_vec_uint64_512_zero() {
     let recovered_value: Vector<u64, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c");
     assert_eq!(root, expected_root);
@@ -20602,7 +20602,7 @@ fn test_basic_vector_vec_uint64_512_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_5_random() {
-    let value = Vector::<U256, 5>::from_iter([
+    let mut value = Vector::<U256, 5>::from_iter([
         U256([
             179, 22, 196, 129, 77, 158, 184, 168, 7, 100, 123, 93, 196, 11, 104, 117, 250, 160,
             128, 244, 88, 117, 73, 178, 87, 111, 186, 153, 1, 54, 206, 160,
@@ -20633,7 +20633,7 @@ fn test_basic_vector_vec_uint256_5_random() {
     let recovered_value: Vector<U256, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2080573f384b29b3453b8cc44a967325a2e9ad22cb1b3f1d81554bb11479c2bc");
     assert_eq!(root, expected_root);
@@ -20641,7 +20641,7 @@ fn test_basic_vector_vec_uint256_5_random() {
 
 #[test]
 fn test_basic_vector_vec_uint256_1_max() {
-    let value = Vector::<U256, 1>::from_iter([U256([
+    let mut value = Vector::<U256, 1>::from_iter([U256([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ])]);
@@ -20654,7 +20654,7 @@ fn test_basic_vector_vec_uint256_1_max() {
     let recovered_value: Vector<U256, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -20662,7 +20662,7 @@ fn test_basic_vector_vec_uint256_1_max() {
 
 #[test]
 fn test_basic_vector_vec_uint16_513_max() {
-    let value = Vector::<u16, 513>::from_iter([
+    let mut value = Vector::<u16, 513>::from_iter([
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -20713,7 +20713,7 @@ fn test_basic_vector_vec_uint16_513_max() {
     let recovered_value: Vector<u16, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("193411b011bc1acbf600803324bc5dc359acef14c1be285ef7565186c0ea9b10");
     assert_eq!(root, expected_root);
@@ -20721,7 +20721,7 @@ fn test_basic_vector_vec_uint16_513_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_513_max() {
-    let value = Vector::<u64, 513>::from_iter([
+    let mut value = Vector::<u64, 513>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -21245,7 +21245,7 @@ fn test_basic_vector_vec_uint64_513_max() {
     let recovered_value: Vector<u64, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("76e07c25312b02171801bc5bfa77a4c4f65ca1a93464d9812362009307ecfb55");
     assert_eq!(root, expected_root);
@@ -21253,7 +21253,7 @@ fn test_basic_vector_vec_uint64_513_max() {
 
 #[test]
 fn test_basic_vector_vec_uint32_1_random() {
-    let value = Vector::<u32, 1>::from_iter([1797257601]);
+    let mut value = Vector::<u32, 1>::from_iter([1797257601]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_1_random/serialized.ssz_snappy",
@@ -21263,7 +21263,7 @@ fn test_basic_vector_vec_uint32_1_random() {
     let recovered_value: Vector<u32, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("81f91f6b00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -21271,7 +21271,7 @@ fn test_basic_vector_vec_uint32_1_random() {
 
 #[test]
 fn test_basic_vector_vec_uint128_4_zero() {
-    let value = Vector::<u128, 4>::from_iter([0, 0, 0, 0]);
+    let mut value = Vector::<u128, 4>::from_iter([0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint128_4_zero/serialized.ssz_snappy",
@@ -21281,7 +21281,7 @@ fn test_basic_vector_vec_uint128_4_zero() {
     let recovered_value: Vector<u128, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -21289,7 +21289,7 @@ fn test_basic_vector_vec_uint128_4_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint256_4_zero() {
-    let value = Vector::<U256, 4>::from_iter([
+    let mut value = Vector::<U256, 4>::from_iter([
         U256([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -21316,7 +21316,7 @@ fn test_basic_vector_vec_uint256_4_zero() {
     let recovered_value: Vector<U256, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -21324,7 +21324,7 @@ fn test_basic_vector_vec_uint256_4_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint128_3_random() {
-    let value = Vector::<u128, 3>::from_iter([
+    let mut value = Vector::<u128, 3>::from_iter([
         220301989141709271334326095341414922102,
         210235080945710533958926333282570767995,
         38717160196772117737433576948282568669,
@@ -21338,7 +21338,7 @@ fn test_basic_vector_vec_uint128_3_random() {
     let recovered_value: Vector<u128, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5376f444f73d42d4319e96d18c1d78ffab3f12464280dee8cf1df519ff50d628");
     assert_eq!(root, expected_root);
@@ -21346,7 +21346,7 @@ fn test_basic_vector_vec_uint128_3_random() {
 
 #[test]
 fn test_basic_vector_vec_uint256_3_max() {
-    let value = Vector::<U256, 3>::from_iter([
+    let mut value = Vector::<U256, 3>::from_iter([
         U256([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -21369,7 +21369,7 @@ fn test_basic_vector_vec_uint256_3_max() {
     let recovered_value: Vector<U256, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4a6ba660d16b4dde152d00ba82cdde34827411f341c56b102e7962410924ad36");
     assert_eq!(root, expected_root);
@@ -21377,7 +21377,7 @@ fn test_basic_vector_vec_uint256_3_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_31_zero() {
-    let value = Vector::<u128, 31>::from_iter([
+    let mut value = Vector::<u128, 31>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
     let encoding = serialize(&value);
@@ -21389,7 +21389,7 @@ fn test_basic_vector_vec_uint128_31_zero() {
     let recovered_value: Vector<u128, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c");
     assert_eq!(root, expected_root);
@@ -21397,7 +21397,7 @@ fn test_basic_vector_vec_uint128_31_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint16_3_zero() {
-    let value = Vector::<u16, 3>::from_iter([0, 0, 0]);
+    let mut value = Vector::<u16, 3>::from_iter([0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint16_3_zero/serialized.ssz_snappy",
@@ -21407,7 +21407,7 @@ fn test_basic_vector_vec_uint16_3_zero() {
     let recovered_value: Vector<u16, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -21415,7 +21415,7 @@ fn test_basic_vector_vec_uint16_3_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint8_513_random() {
-    let value = Vector::<u8, 513>::from_iter([
+    let mut value = Vector::<u8, 513>::from_iter([
         43, 14, 152, 176, 220, 9, 200, 233, 44, 111, 40, 178, 171, 180, 198, 181, 48, 15, 66, 68,
         230, 183, 64, 49, 31, 136, 81, 16, 173, 252, 42, 222, 184, 9, 215, 161, 98, 84, 117, 216,
         87, 221, 255, 71, 194, 243, 197, 156, 141, 132, 73, 183, 67, 133, 159, 127, 151, 85, 79,
@@ -21453,7 +21453,7 @@ fn test_basic_vector_vec_uint8_513_random() {
     let recovered_value: Vector<u8, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fd0fdfd0c2ccb9a01421e330f2054910070c6b53353a8ddefad470286f00c6f0");
     assert_eq!(root, expected_root);
@@ -21461,7 +21461,7 @@ fn test_basic_vector_vec_uint8_513_random() {
 
 #[test]
 fn test_basic_vector_vec_bool_16_max() {
-    let value = Vector::<bool, 16>::from_iter([
+    let mut value = Vector::<bool, 16>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true,
     ]);
@@ -21474,7 +21474,7 @@ fn test_basic_vector_vec_bool_16_max() {
     let recovered_value: Vector<bool, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0101010101010101010101010101010100000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -21482,7 +21482,7 @@ fn test_basic_vector_vec_bool_16_max() {
 
 #[test]
 fn test_basic_vector_vec_uint256_2_max() {
-    let value = Vector::<U256, 2>::from_iter([
+    let mut value = Vector::<U256, 2>::from_iter([
         U256([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -21501,7 +21501,7 @@ fn test_basic_vector_vec_uint256_2_max() {
     let recovered_value: Vector<U256, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -21509,7 +21509,7 @@ fn test_basic_vector_vec_uint256_2_max() {
 
 #[test]
 fn test_basic_vector_vec_uint128_31_max() {
-    let value = Vector::<u128, 31>::from_iter([
+    let mut value = Vector::<u128, 31>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -21551,7 +21551,7 @@ fn test_basic_vector_vec_uint128_31_max() {
     let recovered_value: Vector<u128, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("661455692304dacd704fda4ac469deedd8783f5353c7120b35ceab4309536e81");
     assert_eq!(root, expected_root);
@@ -21559,7 +21559,7 @@ fn test_basic_vector_vec_uint128_31_max() {
 
 #[test]
 fn test_basic_vector_vec_uint64_513_random() {
-    let value = Vector::<u64, 513>::from_iter([
+    let mut value = Vector::<u64, 513>::from_iter([
         977103724348450572,
         16638432304304789571,
         12981575418293692183,
@@ -22083,7 +22083,7 @@ fn test_basic_vector_vec_uint64_513_random() {
     let recovered_value: Vector<u64, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f6fe5bb836cca4115fcca592f3ca646c0d56b4ab316eb8f469c372846ec6d7f6");
     assert_eq!(root, expected_root);
@@ -22091,7 +22091,7 @@ fn test_basic_vector_vec_uint64_513_random() {
 
 #[test]
 fn test_basic_vector_vec_uint128_31_random() {
-    let value = Vector::<u128, 31>::from_iter([
+    let mut value = Vector::<u128, 31>::from_iter([
         322161099503949134246875383873042092581,
         48424120129033191202980611955490263589,
         83525771833522514138478832606095687392,
@@ -22133,7 +22133,7 @@ fn test_basic_vector_vec_uint128_31_random() {
     let recovered_value: Vector<u128, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6f8bfa11523cb7f78e6dabe9796ad0cb5b4730f6647c77164474985034ce1eba");
     assert_eq!(root, expected_root);
@@ -22141,7 +22141,7 @@ fn test_basic_vector_vec_uint128_31_random() {
 
 #[test]
 fn test_basic_vector_vec_uint128_8_zero() {
-    let value = Vector::<u128, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
+    let mut value = Vector::<u128, 8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint128_8_zero/serialized.ssz_snappy",
@@ -22151,7 +22151,7 @@ fn test_basic_vector_vec_uint128_8_zero() {
     let recovered_value: Vector<u128, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -22159,7 +22159,7 @@ fn test_basic_vector_vec_uint128_8_zero() {
 
 #[test]
 fn test_basic_vector_vec_uint32_3_zero() {
-    let value = Vector::<u32, 3>::from_iter([0, 0, 0]);
+    let mut value = Vector::<u32, 3>::from_iter([0, 0, 0]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/basic_vector/valid/vec_uint32_3_zero/serialized.ssz_snappy",
@@ -22169,7 +22169,7 @@ fn test_basic_vector_vec_uint32_3_zero() {
     let recovered_value: Vector<u32, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);

--- a/ssz_rs/tests/bitlist.rs
+++ b/ssz_rs/tests/bitlist.rs
@@ -7,7 +7,7 @@ use test_utils::{
 
 #[test]
 fn test_bitlist_bitlist_8_random_4() {
-    let value = Bitlist::<8>::from_iter([true, true, true]);
+    let mut value = Bitlist::<8>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_random_4/serialized.ssz_snappy",
@@ -17,7 +17,7 @@ fn test_bitlist_bitlist_8_random_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -25,7 +25,7 @@ fn test_bitlist_bitlist_8_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_2() {
-    let value = Bitlist::<16>::from_iter([true, true, false, true, true, true, false, false]);
+    let mut value = Bitlist::<16>::from_iter([true, true, false, true, true, true, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_random_2/serialized.ssz_snappy",
@@ -35,7 +35,7 @@ fn test_bitlist_bitlist_16_random_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8bd00e1a82454504a094276182544df713103259ba3f96133871a55281b44d18");
     assert_eq!(root, expected_root);
@@ -43,7 +43,7 @@ fn test_bitlist_bitlist_16_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_0() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         false, false, true, false, false, false, false, false, true, true, false, true, false,
         true, true, false, true, false, true, false, true, true, true, true, false, false, true,
         false, true, true, true,
@@ -57,7 +57,7 @@ fn test_bitlist_bitlist_31_lengthy_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2b4e175a3cabe516e47026098d7a07a105d94c6e1d7859c5f8e99d81d5fb73e5");
     assert_eq!(root, expected_root);
@@ -65,7 +65,7 @@ fn test_bitlist_bitlist_31_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_random_3() {
-    let value = Bitlist::<8>::from_iter([false]);
+    let mut value = Bitlist::<8>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_random_3/serialized.ssz_snappy",
@@ -75,7 +75,7 @@ fn test_bitlist_bitlist_8_random_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -83,7 +83,7 @@ fn test_bitlist_bitlist_8_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_2() {
-    let value = Bitlist::<3>::from_iter([true, false]);
+    let mut value = Bitlist::<3>::from_iter([true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_random_2/serialized.ssz_snappy",
@@ -93,7 +93,7 @@ fn test_bitlist_bitlist_3_random_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff55c97976a840b4ced964ed49e3794594ba3f675238b5fd25d282b60f70a194");
     assert_eq!(root, expected_root);
@@ -101,7 +101,7 @@ fn test_bitlist_bitlist_3_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_2() {
-    let value = Bitlist::<2>::from_iter([true, true]);
+    let mut value = Bitlist::<2>::from_iter([true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_random_2/serialized.ssz_snappy",
@@ -111,7 +111,7 @@ fn test_bitlist_bitlist_2_random_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -119,7 +119,7 @@ fn test_bitlist_bitlist_2_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_4() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true,
     ]);
     let encoding = serialize(&value);
@@ -131,7 +131,7 @@ fn test_bitlist_bitlist_31_max_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4b5bcf109d8b0381e1ca551794c9fb864838f5b07057e05da75830f7999d96de");
     assert_eq!(root, expected_root);
@@ -139,7 +139,7 @@ fn test_bitlist_bitlist_31_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_1() {
-    let value = Bitlist::<4>::from_iter([]);
+    let mut value = Bitlist::<4>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_nil_1/serialized.ssz_snappy",
@@ -149,7 +149,7 @@ fn test_bitlist_bitlist_4_nil_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -157,7 +157,7 @@ fn test_bitlist_bitlist_4_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_3() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true,
     ]);
@@ -170,7 +170,7 @@ fn test_bitlist_bitlist_31_max_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b8570b9c932d5fd3d2bd727a64d527f790d8261acd9f6ce2786cc1fa34dd2fa8");
     assert_eq!(root, expected_root);
@@ -178,7 +178,7 @@ fn test_bitlist_bitlist_31_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_0() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_max_0/serialized.ssz_snappy",
@@ -188,7 +188,7 @@ fn test_bitlist_bitlist_2_max_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -196,7 +196,7 @@ fn test_bitlist_bitlist_2_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_4() {
-    let value = Bitlist::<4>::from_iter([false, false, false, false]);
+    let mut value = Bitlist::<4>::from_iter([false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_zero_4/serialized.ssz_snappy",
@@ -206,7 +206,7 @@ fn test_bitlist_bitlist_4_zero_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);
@@ -214,7 +214,7 @@ fn test_bitlist_bitlist_4_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_3() {
-    let value = Bitlist::<4>::from_iter([false, false]);
+    let mut value = Bitlist::<4>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_zero_3/serialized.ssz_snappy",
@@ -224,7 +224,7 @@ fn test_bitlist_bitlist_4_zero_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -232,7 +232,7 @@ fn test_bitlist_bitlist_4_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_1() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         true, false, false, true, true, true, false, false, true, true, false, true, true, false,
         true, false, false, false, true, false, false, true, false, false, true, true, false, true,
         true, true, false, true, false, false, false, false, false, false, true, false, false,
@@ -281,7 +281,7 @@ fn test_bitlist_bitlist_513_lengthy_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("10041d4cf07da1077e84c9b5c01fa6d5f29ba8feb934ebdf7ca184a2857cdf55");
     assert_eq!(root, expected_root);
@@ -289,7 +289,7 @@ fn test_bitlist_bitlist_513_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_1() {
-    let value = Bitlist::<5>::from_iter([false, false, false, false, false]);
+    let mut value = Bitlist::<5>::from_iter([false, false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_zero_1/serialized.ssz_snappy",
@@ -299,7 +299,7 @@ fn test_bitlist_bitlist_5_zero_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("16aaf795af421b6156d4c3319879d422a0c3ffd26db07207a54d6cafcbef0b10");
     assert_eq!(root, expected_root);
@@ -307,7 +307,7 @@ fn test_bitlist_bitlist_5_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_3() {
-    let value = Bitlist::<8>::from_iter([false, false, false, false, false, false]);
+    let mut value = Bitlist::<8>::from_iter([false, false, false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_zero_3/serialized.ssz_snappy",
@@ -317,7 +317,7 @@ fn test_bitlist_bitlist_8_zero_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7d360196d14b15261c9e5f576df8dc8b48d18d79b4198f167741052747704352");
     assert_eq!(root, expected_root);
@@ -325,7 +325,7 @@ fn test_bitlist_bitlist_8_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_0() {
-    let value = Bitlist::<513>::from_iter([]);
+    let mut value = Bitlist::<513>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_513_nil_0/serialized.ssz_snappy",
@@ -335,7 +335,7 @@ fn test_bitlist_bitlist_513_nil_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -343,7 +343,7 @@ fn test_bitlist_bitlist_513_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_4() {
-    let value = Bitlist::<8>::from_iter([false, false, false, false]);
+    let mut value = Bitlist::<8>::from_iter([false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_zero_4/serialized.ssz_snappy",
@@ -353,7 +353,7 @@ fn test_bitlist_bitlist_8_zero_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);
@@ -361,7 +361,7 @@ fn test_bitlist_bitlist_8_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_0() {
-    let value = Bitlist::<2>::from_iter([true, true]);
+    let mut value = Bitlist::<2>::from_iter([true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_lengthy_0/serialized.ssz_snappy",
@@ -371,7 +371,7 @@ fn test_bitlist_bitlist_2_lengthy_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -379,7 +379,7 @@ fn test_bitlist_bitlist_2_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_0() {
-    let value = Bitlist::<4>::from_iter([]);
+    let mut value = Bitlist::<4>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_nil_0/serialized.ssz_snappy",
@@ -389,7 +389,7 @@ fn test_bitlist_bitlist_4_nil_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -397,7 +397,7 @@ fn test_bitlist_bitlist_4_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_2() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true,
     ]);
@@ -410,7 +410,7 @@ fn test_bitlist_bitlist_31_max_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e78c29807c3f3ced69109d22d734a1c69d361e0671c21b8681a1761333e95537");
     assert_eq!(root, expected_root);
@@ -418,7 +418,7 @@ fn test_bitlist_bitlist_31_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_8_random_2() {
-    let value = Bitlist::<8>::from_iter([false]);
+    let mut value = Bitlist::<8>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_random_2/serialized.ssz_snappy",
@@ -428,7 +428,7 @@ fn test_bitlist_bitlist_8_random_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -436,7 +436,7 @@ fn test_bitlist_bitlist_8_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_3() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_random_3/serialized.ssz_snappy",
@@ -446,7 +446,7 @@ fn test_bitlist_bitlist_3_random_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -454,7 +454,7 @@ fn test_bitlist_bitlist_3_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_3() {
-    let value = Bitlist::<2>::from_iter([true]);
+    let mut value = Bitlist::<2>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_random_3/serialized.ssz_snappy",
@@ -464,7 +464,7 @@ fn test_bitlist_bitlist_2_random_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -472,7 +472,7 @@ fn test_bitlist_bitlist_2_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_4() {
-    let value = Bitlist::<16>::from_iter([true, false, false, true]);
+    let mut value = Bitlist::<16>::from_iter([true, false, false, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_random_4/serialized.ssz_snappy",
@@ -482,7 +482,7 @@ fn test_bitlist_bitlist_16_random_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("53de69c30b9c07be9cba006e32db34dc1e4ebfe649bc94aa7c8aae0ef419aeed");
     assert_eq!(root, expected_root);
@@ -490,7 +490,7 @@ fn test_bitlist_bitlist_16_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_3() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         false, false, false, true, false, true, true, false, true, true, true, false,
     ]);
     let encoding = serialize(&value);
@@ -502,7 +502,7 @@ fn test_bitlist_bitlist_16_random_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("160937bf5c6f4256c285385214969c965a8c841be474c62d7ed3c184ec3cdb69");
     assert_eq!(root, expected_root);
@@ -510,7 +510,7 @@ fn test_bitlist_bitlist_16_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_1() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         false, false, false, false, true, false, false, false, true, true, false, true, false,
         true, false, false, true, true, false, false, true, false, true, true, true, false, true,
         true, true, false, true,
@@ -524,7 +524,7 @@ fn test_bitlist_bitlist_31_lengthy_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5054e572357a7c57c9f05e8f79208348c9dfe9f28461d7935700459b1ae2307");
     assert_eq!(root, expected_root);
@@ -532,7 +532,7 @@ fn test_bitlist_bitlist_31_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_4() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_random_4/serialized.ssz_snappy",
@@ -542,7 +542,7 @@ fn test_bitlist_bitlist_2_random_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -550,7 +550,7 @@ fn test_bitlist_bitlist_2_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_4() {
-    let value = Bitlist::<3>::from_iter([false, false]);
+    let mut value = Bitlist::<3>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_random_4/serialized.ssz_snappy",
@@ -560,7 +560,7 @@ fn test_bitlist_bitlist_3_random_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -568,7 +568,7 @@ fn test_bitlist_bitlist_3_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_1() {
-    let value = Bitlist::<513>::from_iter([]);
+    let mut value = Bitlist::<513>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_513_nil_1/serialized.ssz_snappy",
@@ -578,7 +578,7 @@ fn test_bitlist_bitlist_513_nil_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -586,7 +586,7 @@ fn test_bitlist_bitlist_513_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_1() {
-    let value = Bitlist::<2>::from_iter([true, false]);
+    let mut value = Bitlist::<2>::from_iter([true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_lengthy_1/serialized.ssz_snappy",
@@ -596,7 +596,7 @@ fn test_bitlist_bitlist_2_lengthy_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff55c97976a840b4ced964ed49e3794594ba3f675238b5fd25d282b60f70a194");
     assert_eq!(root, expected_root);
@@ -604,7 +604,7 @@ fn test_bitlist_bitlist_2_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_0() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, false, false, true, false, true, true, false, false, false, true, true, false, true,
         true, false, true, true, false, false, true, false, false, true, false, true, false, false,
         true, false, true, false, true, true, true, false, true, true, true, true, false, true,
@@ -653,7 +653,7 @@ fn test_bitlist_bitlist_513_lengthy_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("77184930e328732d5413240f6114e269a9df6573d8b177f03d328eda7d3ffae2");
     assert_eq!(root, expected_root);
@@ -661,7 +661,7 @@ fn test_bitlist_bitlist_513_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_0() {
-    let value = Bitlist::<5>::from_iter([false, false]);
+    let mut value = Bitlist::<5>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_zero_0/serialized.ssz_snappy",
@@ -671,7 +671,7 @@ fn test_bitlist_bitlist_5_zero_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -679,7 +679,7 @@ fn test_bitlist_bitlist_5_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_2() {
-    let value = Bitlist::<8>::from_iter([false, false, false, false, false, false]);
+    let mut value = Bitlist::<8>::from_iter([false, false, false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_zero_2/serialized.ssz_snappy",
@@ -689,7 +689,7 @@ fn test_bitlist_bitlist_8_zero_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7d360196d14b15261c9e5f576df8dc8b48d18d79b4198f167741052747704352");
     assert_eq!(root, expected_root);
@@ -697,7 +697,7 @@ fn test_bitlist_bitlist_8_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_2() {
-    let value = Bitlist::<4>::from_iter([]);
+    let mut value = Bitlist::<4>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_zero_2/serialized.ssz_snappy",
@@ -707,7 +707,7 @@ fn test_bitlist_bitlist_4_zero_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -715,7 +715,7 @@ fn test_bitlist_bitlist_4_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_1() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_max_1/serialized.ssz_snappy",
@@ -725,7 +725,7 @@ fn test_bitlist_bitlist_2_max_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -733,7 +733,7 @@ fn test_bitlist_bitlist_2_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_1() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_nil_1/serialized.ssz_snappy",
@@ -743,7 +743,7 @@ fn test_bitlist_bitlist_2_nil_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -751,7 +751,7 @@ fn test_bitlist_bitlist_2_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_0() {
-    let value = Bitlist::<4>::from_iter([true, true, false, true]);
+    let mut value = Bitlist::<4>::from_iter([true, true, false, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_lengthy_0/serialized.ssz_snappy",
@@ -761,7 +761,7 @@ fn test_bitlist_bitlist_4_lengthy_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9d2816f451512382c000156fad1578555537321084d091d3c7b228aa705c36aa");
     assert_eq!(root, expected_root);
@@ -769,7 +769,7 @@ fn test_bitlist_bitlist_4_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_1() {
-    let value = Bitlist::<513>::from_iter([true, true, true, true, true, true]);
+    let mut value = Bitlist::<513>::from_iter([true, true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_513_max_1/serialized.ssz_snappy",
@@ -779,7 +779,7 @@ fn test_bitlist_bitlist_513_max_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b00f282b126680bcbd302d657b117dc32294c4cb586f76c244932141012e6a82");
     assert_eq!(root, expected_root);
@@ -787,7 +787,7 @@ fn test_bitlist_bitlist_513_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_0() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         false, false, false, false, false, true, false, true, false, false, true, true, true,
         false, true, false,
     ]);
@@ -800,7 +800,7 @@ fn test_bitlist_bitlist_16_lengthy_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6232812aa34ca3e9ce77374f8915f059832b1671edbbe38e8816196b2be450d5");
     assert_eq!(root, expected_root);
@@ -808,7 +808,7 @@ fn test_bitlist_bitlist_16_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_0() {
-    let value = Bitlist::<4>::from_iter([true, true, true]);
+    let mut value = Bitlist::<4>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_max_0/serialized.ssz_snappy",
@@ -818,7 +818,7 @@ fn test_bitlist_bitlist_4_max_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -826,7 +826,7 @@ fn test_bitlist_bitlist_4_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_0() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_random_0/serialized.ssz_snappy",
@@ -836,7 +836,7 @@ fn test_bitlist_bitlist_1_random_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -844,7 +844,7 @@ fn test_bitlist_bitlist_1_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_2() {
-    let value = Bitlist::<31>::from_iter([]);
+    let mut value = Bitlist::<31>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_nil_2/serialized.ssz_snappy",
@@ -854,7 +854,7 @@ fn test_bitlist_bitlist_31_nil_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -862,7 +862,7 @@ fn test_bitlist_bitlist_31_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_0() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -885,7 +885,7 @@ fn test_bitlist_bitlist_513_max_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3116c9a3fab7c6ebf0978f8ef07aa2c27ea9c79887d773980a39b95e5c035593");
     assert_eq!(root, expected_root);
@@ -893,7 +893,7 @@ fn test_bitlist_bitlist_513_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_1() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         false, false, false, false, false, false, true, false, true, true, false, false, true,
         true, false, true,
     ]);
@@ -906,7 +906,7 @@ fn test_bitlist_bitlist_16_lengthy_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8c2b7bd1b88a7d1be36dad5c3734873af45f38d2d4618f83211b394aa65a665e");
     assert_eq!(root, expected_root);
@@ -914,7 +914,7 @@ fn test_bitlist_bitlist_16_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_1() {
-    let value = Bitlist::<4>::from_iter([true, false, true, false]);
+    let mut value = Bitlist::<4>::from_iter([true, false, true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_lengthy_1/serialized.ssz_snappy",
@@ -924,7 +924,7 @@ fn test_bitlist_bitlist_4_lengthy_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e90722eb4d2a891700f1f3aa2e95661e707b19e60e147a96f8cf089e8cbc4bec");
     assert_eq!(root, expected_root);
@@ -932,7 +932,7 @@ fn test_bitlist_bitlist_4_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_0() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_nil_0/serialized.ssz_snappy",
@@ -942,7 +942,7 @@ fn test_bitlist_bitlist_2_nil_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -950,7 +950,7 @@ fn test_bitlist_bitlist_2_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_1() {
-    let value = Bitlist::<4>::from_iter([true]);
+    let mut value = Bitlist::<4>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_max_1/serialized.ssz_snappy",
@@ -960,7 +960,7 @@ fn test_bitlist_bitlist_4_max_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -968,7 +968,7 @@ fn test_bitlist_bitlist_4_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_1() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_random_1/serialized.ssz_snappy",
@@ -978,7 +978,7 @@ fn test_bitlist_bitlist_1_random_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -986,7 +986,7 @@ fn test_bitlist_bitlist_1_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_3() {
-    let value = Bitlist::<31>::from_iter([]);
+    let mut value = Bitlist::<31>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_nil_3/serialized.ssz_snappy",
@@ -996,7 +996,7 @@ fn test_bitlist_bitlist_31_nil_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1004,7 +1004,7 @@ fn test_bitlist_bitlist_31_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_4() {
-    let value = Bitlist::<31>::from_iter([]);
+    let mut value = Bitlist::<31>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_nil_4/serialized.ssz_snappy",
@@ -1014,7 +1014,7 @@ fn test_bitlist_bitlist_31_nil_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1022,7 +1022,7 @@ fn test_bitlist_bitlist_31_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_3() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true,
     ]);
     let encoding = serialize(&value);
@@ -1034,7 +1034,7 @@ fn test_bitlist_bitlist_16_max_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("16472e350c0d8e0cf112307b5cfa66561668ffef5f9f3281c9ad0af85122ba2c");
     assert_eq!(root, expected_root);
@@ -1042,7 +1042,7 @@ fn test_bitlist_bitlist_16_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_0() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_zero_0/serialized.ssz_snappy",
@@ -1052,7 +1052,7 @@ fn test_bitlist_bitlist_3_zero_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1060,7 +1060,7 @@ fn test_bitlist_bitlist_3_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_1() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, true, false, true, false, false, false, true, false, true, true, false, true, false,
         true, true, false, false, true, false, false, true, false, false, true, true, true, true,
         true, true, true, false, false, false, true, false, false, false, false, false, false,
@@ -1075,7 +1075,7 @@ fn test_bitlist_bitlist_512_random_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4979bcefe3ded00d52ea1342595d1390e372a93c4acf10ed2c3c1fc604d1a92e");
     assert_eq!(root, expected_root);
@@ -1083,7 +1083,7 @@ fn test_bitlist_bitlist_512_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_1() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         true, false, true, false, true, true, true, true, true, false, false, false, false, true,
         false, true, true, true, true, false, false, true, true, false, true, true, true, false,
         false, false, false, true, false, false, false, true, true, true, false, true, true, false,
@@ -1113,7 +1113,7 @@ fn test_bitlist_bitlist_513_random_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("339f84a3e78443af74c3ea49f06c6d1933f3b4e3440dc631820662651085a306");
     assert_eq!(root, expected_root);
@@ -1121,7 +1121,7 @@ fn test_bitlist_bitlist_513_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_0() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -1153,7 +1153,7 @@ fn test_bitlist_bitlist_513_zero_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3f398072fb9acafba24683799d8250de322a96a12e3016134220db24526b372d");
     assert_eq!(root, expected_root);
@@ -1161,7 +1161,7 @@ fn test_bitlist_bitlist_513_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_4() {
-    let value = Bitlist::<16>::from_iter([true, true, true, true]);
+    let mut value = Bitlist::<16>::from_iter([true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_max_4/serialized.ssz_snappy",
@@ -1171,7 +1171,7 @@ fn test_bitlist_bitlist_16_max_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4b07c3799db025f3aa92ced1e8545367a2b6e44960f479d3f9d62b61812892d5");
     assert_eq!(root, expected_root);
@@ -1179,7 +1179,7 @@ fn test_bitlist_bitlist_16_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_0() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_max_0/serialized.ssz_snappy",
@@ -1189,7 +1189,7 @@ fn test_bitlist_bitlist_1_max_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1197,7 +1197,7 @@ fn test_bitlist_bitlist_1_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_2() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -1229,7 +1229,7 @@ fn test_bitlist_bitlist_512_zero_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0f4ea9e6bc6fce537e76838bafa08072aec839c4acc1d3a8c62bb4a253a0a451");
     assert_eq!(root, expected_root);
@@ -1237,7 +1237,7 @@ fn test_bitlist_bitlist_512_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_2() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_zero_2/serialized.ssz_snappy",
@@ -1247,7 +1247,7 @@ fn test_bitlist_bitlist_2_zero_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1255,7 +1255,7 @@ fn test_bitlist_bitlist_2_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_0() {
-    let value = Bitlist::<5>::from_iter([]);
+    let mut value = Bitlist::<5>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_nil_0/serialized.ssz_snappy",
@@ -1265,7 +1265,7 @@ fn test_bitlist_bitlist_5_nil_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1273,7 +1273,7 @@ fn test_bitlist_bitlist_5_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_1() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, true, true, true, true, false, true, false, false, false, false, true, true, true,
         false, true, true, false, false, false, false, false, false, false, true, true, false,
         false, false, true, true, false, true, false, false, false, true, true, false, false, true,
@@ -1322,7 +1322,7 @@ fn test_bitlist_bitlist_512_lengthy_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2b28c2217c3f1f99e0c5ad46c77be392323ae7c6e68612e6b1701e762a0285e7");
     assert_eq!(root, expected_root);
@@ -1330,7 +1330,7 @@ fn test_bitlist_bitlist_512_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_3() {
-    let value = Bitlist::<1>::from_iter([false]);
+    let mut value = Bitlist::<1>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_lengthy_3/serialized.ssz_snappy",
@@ -1340,7 +1340,7 @@ fn test_bitlist_bitlist_1_lengthy_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -1348,7 +1348,7 @@ fn test_bitlist_bitlist_1_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_1() {
-    let value = Bitlist::<3>::from_iter([true, true, true]);
+    let mut value = Bitlist::<3>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_max_1/serialized.ssz_snappy",
@@ -1358,7 +1358,7 @@ fn test_bitlist_bitlist_3_max_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -1366,7 +1366,7 @@ fn test_bitlist_bitlist_3_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_4() {
-    let value = Bitlist::<1>::from_iter([true]);
+    let mut value = Bitlist::<1>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_lengthy_4/serialized.ssz_snappy",
@@ -1376,7 +1376,7 @@ fn test_bitlist_bitlist_1_lengthy_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -1384,7 +1384,7 @@ fn test_bitlist_bitlist_1_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_0() {
-    let value = Bitlist::<3>::from_iter([false, false, false]);
+    let mut value = Bitlist::<3>::from_iter([false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_lengthy_0/serialized.ssz_snappy",
@@ -1394,7 +1394,7 @@ fn test_bitlist_bitlist_3_lengthy_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d86ae2ca925345bf2412bde450ac175742d979c1ea7b961bd1efe10beb9500cf");
     assert_eq!(root, expected_root);
@@ -1402,7 +1402,7 @@ fn test_bitlist_bitlist_3_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_1() {
-    let value = Bitlist::<512>::from_iter([]);
+    let mut value = Bitlist::<512>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_512_nil_1/serialized.ssz_snappy",
@@ -1412,7 +1412,7 @@ fn test_bitlist_bitlist_512_nil_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -1420,7 +1420,7 @@ fn test_bitlist_bitlist_512_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_2() {
-    let value = Bitlist::<8>::from_iter([]);
+    let mut value = Bitlist::<8>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_max_2/serialized.ssz_snappy",
@@ -1430,7 +1430,7 @@ fn test_bitlist_bitlist_8_max_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1438,7 +1438,7 @@ fn test_bitlist_bitlist_8_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_0() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false,
@@ -1452,7 +1452,7 @@ fn test_bitlist_bitlist_31_zero_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6463f4376faab07e62e5a4737d2d95ad690892f8fae0b9559c0ed3ae96bb2790");
     assert_eq!(root, expected_root);
@@ -1460,7 +1460,7 @@ fn test_bitlist_bitlist_31_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_1() {
-    let value = Bitlist::<5>::from_iter([]);
+    let mut value = Bitlist::<5>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_nil_1/serialized.ssz_snappy",
@@ -1470,7 +1470,7 @@ fn test_bitlist_bitlist_5_nil_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1478,7 +1478,7 @@ fn test_bitlist_bitlist_5_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_4() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -1495,7 +1495,7 @@ fn test_bitlist_bitlist_512_zero_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c3f35acbdbda16dc35969a4b0c817b2a7c9f8b037ace72cae4efb76797d8d4c4");
     assert_eq!(root, expected_root);
@@ -1503,7 +1503,7 @@ fn test_bitlist_bitlist_512_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_3() {
-    let value = Bitlist::<2>::from_iter([false]);
+    let mut value = Bitlist::<2>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_zero_3/serialized.ssz_snappy",
@@ -1513,7 +1513,7 @@ fn test_bitlist_bitlist_2_zero_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -1521,7 +1521,7 @@ fn test_bitlist_bitlist_2_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_4() {
-    let value = Bitlist::<2>::from_iter([false]);
+    let mut value = Bitlist::<2>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_zero_4/serialized.ssz_snappy",
@@ -1531,7 +1531,7 @@ fn test_bitlist_bitlist_2_zero_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -1539,7 +1539,7 @@ fn test_bitlist_bitlist_2_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_3() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -1580,7 +1580,7 @@ fn test_bitlist_bitlist_512_zero_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ec7fd7a922a87b641e3c8e0f2b092b1f470050c14409fcd95985c07024a429f4");
     assert_eq!(root, expected_root);
@@ -1588,7 +1588,7 @@ fn test_bitlist_bitlist_512_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_0() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         true, true, true, true, true, false, false, true, true, false, false, false, false, false,
         true, true, true, false, false, false, false, false, true, false, true, true, false, false,
         true, false, true, false, true, false, false, true, true, false, false, true, true, false,
@@ -1622,7 +1622,7 @@ fn test_bitlist_bitlist_512_random_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d01782fa00046d31ecef1828d806bc82a0635ba68a829abaea5bc5e83cfc3b39");
     assert_eq!(root, expected_root);
@@ -1630,7 +1630,7 @@ fn test_bitlist_bitlist_512_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_0() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, false, false, false, true, true, false, true, true, true, true, false, true, false,
         true, true, false, false, true, false, false, true, true, true, false, false, true, false,
         true, true, false, true, true, true, true, false, true, true, false, false, false, true,
@@ -1648,7 +1648,7 @@ fn test_bitlist_bitlist_513_random_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("62110ea980c0e8b321149e2681d66a3c9ca6d2af615ed3f7b2ea1f950519cee3");
     assert_eq!(root, expected_root);
@@ -1656,7 +1656,7 @@ fn test_bitlist_bitlist_513_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_1() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -1703,7 +1703,7 @@ fn test_bitlist_bitlist_513_zero_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("25f3b33649409489b22232a7706a5ae5c4f5b62cadee098a758d3fa16d1087d2");
     assert_eq!(root, expected_root);
@@ -1711,7 +1711,7 @@ fn test_bitlist_bitlist_513_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_1() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_max_1/serialized.ssz_snappy",
@@ -1721,7 +1721,7 @@ fn test_bitlist_bitlist_1_max_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1729,7 +1729,7 @@ fn test_bitlist_bitlist_1_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_1() {
-    let value = Bitlist::<3>::from_iter([false]);
+    let mut value = Bitlist::<3>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_zero_1/serialized.ssz_snappy",
@@ -1739,7 +1739,7 @@ fn test_bitlist_bitlist_3_zero_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -1747,7 +1747,7 @@ fn test_bitlist_bitlist_3_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_2() {
-    let value =
+    let mut value =
         Bitlist::<16>::from_iter([true, true, true, true, true, true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1758,7 +1758,7 @@ fn test_bitlist_bitlist_16_max_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5879404f965b9356ffe1e124c2ef7aef85a31eda844aa967aa74d3422a7e2b2e");
     assert_eq!(root, expected_root);
@@ -1766,7 +1766,7 @@ fn test_bitlist_bitlist_16_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_3() {
-    let value = Bitlist::<8>::from_iter([true, true, true, true, true]);
+    let mut value = Bitlist::<8>::from_iter([true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_max_3/serialized.ssz_snappy",
@@ -1776,7 +1776,7 @@ fn test_bitlist_bitlist_8_max_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb9e73cb5c2e4ef66fa63540f8220301d31eea7edfccedb2b47b9bdf849ccee7");
     assert_eq!(root, expected_root);
@@ -1784,7 +1784,7 @@ fn test_bitlist_bitlist_8_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_0() {
-    let value = Bitlist::<512>::from_iter([]);
+    let mut value = Bitlist::<512>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_512_nil_0/serialized.ssz_snappy",
@@ -1794,7 +1794,7 @@ fn test_bitlist_bitlist_512_nil_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -1802,7 +1802,7 @@ fn test_bitlist_bitlist_512_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_1() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false,
@@ -1816,7 +1816,7 @@ fn test_bitlist_bitlist_31_zero_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7d934ef6667cff3afea0633d57baa9a82a7009f89b0f8c12f47150047098b396");
     assert_eq!(root, expected_root);
@@ -1824,7 +1824,7 @@ fn test_bitlist_bitlist_31_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_4() {
-    let value = Bitlist::<8>::from_iter([]);
+    let mut value = Bitlist::<8>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_max_4/serialized.ssz_snappy",
@@ -1834,7 +1834,7 @@ fn test_bitlist_bitlist_8_max_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1842,7 +1842,7 @@ fn test_bitlist_bitlist_8_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_1() {
-    let value = Bitlist::<3>::from_iter([false, false, false]);
+    let mut value = Bitlist::<3>::from_iter([false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_lengthy_1/serialized.ssz_snappy",
@@ -1852,7 +1852,7 @@ fn test_bitlist_bitlist_3_lengthy_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d86ae2ca925345bf2412bde450ac175742d979c1ea7b961bd1efe10beb9500cf");
     assert_eq!(root, expected_root);
@@ -1860,7 +1860,7 @@ fn test_bitlist_bitlist_3_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_0() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, false, false, false, false, false, false, false, true, false, false, true, false,
         true, false, false, false, false, false, false, false, false, false, true, false, false,
         true, true, true, false, false, true, true, false, false, false, false, false, true, false,
@@ -1909,7 +1909,7 @@ fn test_bitlist_bitlist_512_lengthy_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("bc152fc83f6fefea40b3b3fdf626dc1af7eaea74e6bce7aba12a6602679004e1");
     assert_eq!(root, expected_root);
@@ -1917,7 +1917,7 @@ fn test_bitlist_bitlist_512_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_0() {
-    let value = Bitlist::<3>::from_iter([true, true, true]);
+    let mut value = Bitlist::<3>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_max_0/serialized.ssz_snappy",
@@ -1927,7 +1927,7 @@ fn test_bitlist_bitlist_3_max_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -1935,7 +1935,7 @@ fn test_bitlist_bitlist_3_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_2() {
-    let value = Bitlist::<1>::from_iter([false]);
+    let mut value = Bitlist::<1>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_lengthy_2/serialized.ssz_snappy",
@@ -1945,7 +1945,7 @@ fn test_bitlist_bitlist_1_lengthy_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -1953,7 +1953,7 @@ fn test_bitlist_bitlist_1_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_0() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_nil_0/serialized.ssz_snappy",
@@ -1963,7 +1963,7 @@ fn test_bitlist_bitlist_3_nil_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1971,7 +1971,7 @@ fn test_bitlist_bitlist_3_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_1() {
-    let value = Bitlist::<31>::from_iter([false, true, false, true, false, true, true, false]);
+    let mut value = Bitlist::<31>::from_iter([false, true, false, true, false, true, true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_random_1/serialized.ssz_snappy",
@@ -1981,7 +1981,7 @@ fn test_bitlist_bitlist_31_random_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("62681102fbb14f3973d9db3e302be35e5bbd79984aed6a85c532c63189afb38a");
     assert_eq!(root, expected_root);
@@ -1989,7 +1989,7 @@ fn test_bitlist_bitlist_31_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_3() {
-    let value = Bitlist::<16>::from_iter([false, false, false, false, false, false]);
+    let mut value = Bitlist::<16>::from_iter([false, false, false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_zero_3/serialized.ssz_snappy",
@@ -1999,7 +1999,7 @@ fn test_bitlist_bitlist_16_zero_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7d360196d14b15261c9e5f576df8dc8b48d18d79b4198f167741052747704352");
     assert_eq!(root, expected_root);
@@ -2007,7 +2007,7 @@ fn test_bitlist_bitlist_16_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_2() {
-    let value = Bitlist::<4>::from_iter([true]);
+    let mut value = Bitlist::<4>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_random_2/serialized.ssz_snappy",
@@ -2017,7 +2017,7 @@ fn test_bitlist_bitlist_4_random_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -2025,7 +2025,7 @@ fn test_bitlist_bitlist_4_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_2() {
-    let value = Bitlist::<5>::from_iter([true]);
+    let mut value = Bitlist::<5>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_random_2/serialized.ssz_snappy",
@@ -2035,7 +2035,7 @@ fn test_bitlist_bitlist_5_random_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -2043,7 +2043,7 @@ fn test_bitlist_bitlist_5_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_1() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_zero_1/serialized.ssz_snappy",
@@ -2053,7 +2053,7 @@ fn test_bitlist_bitlist_1_zero_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2061,7 +2061,7 @@ fn test_bitlist_bitlist_1_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_0() {
-    let value = Bitlist::<5>::from_iter([false, false, true, false, false]);
+    let mut value = Bitlist::<5>::from_iter([false, false, true, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_lengthy_0/serialized.ssz_snappy",
@@ -2071,7 +2071,7 @@ fn test_bitlist_bitlist_5_lengthy_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("bd50456d5ad175ae99a1612a53ca229124b65d3eaabd9ff9c7ab979a385cf6b3");
     assert_eq!(root, expected_root);
@@ -2079,7 +2079,7 @@ fn test_bitlist_bitlist_5_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_4() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false,
     ]);
@@ -2092,7 +2092,7 @@ fn test_bitlist_bitlist_16_zero_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a44a029e04493b8d2fe7893391c2b3ceefec1603c585aad6203f2d14e07bfead");
     assert_eq!(root, expected_root);
@@ -2100,7 +2100,7 @@ fn test_bitlist_bitlist_16_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_4() {
-    let value = Bitlist::<8>::from_iter([]);
+    let mut value = Bitlist::<8>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_nil_4/serialized.ssz_snappy",
@@ -2110,7 +2110,7 @@ fn test_bitlist_bitlist_8_nil_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2118,7 +2118,7 @@ fn test_bitlist_bitlist_8_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_0() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -2149,7 +2149,7 @@ fn test_bitlist_bitlist_512_max_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("bbf3224946b87b12d7c3c24d4887a1a1bdb6afd356e3fb40bfa7a42cd0a7d478");
     assert_eq!(root, expected_root);
@@ -2157,7 +2157,7 @@ fn test_bitlist_bitlist_512_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_3() {
-    let value = Bitlist::<8>::from_iter([]);
+    let mut value = Bitlist::<8>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_nil_3/serialized.ssz_snappy",
@@ -2167,7 +2167,7 @@ fn test_bitlist_bitlist_8_nil_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2175,7 +2175,7 @@ fn test_bitlist_bitlist_8_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_1() {
-    let value = Bitlist::<8>::from_iter([false, false, true, false, true, true, false, true]);
+    let mut value = Bitlist::<8>::from_iter([false, false, true, false, true, true, false, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_lengthy_1/serialized.ssz_snappy",
@@ -2185,7 +2185,7 @@ fn test_bitlist_bitlist_8_lengthy_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5b6af4c3df02247b90fc3736e0a2ff746b5a7f7dc54e7edc66bbb0f68f1b7206");
     assert_eq!(root, expected_root);
@@ -2193,7 +2193,7 @@ fn test_bitlist_bitlist_8_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_2() {
-    let value = Bitlist::<16>::from_iter([]);
+    let mut value = Bitlist::<16>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_nil_2/serialized.ssz_snappy",
@@ -2203,7 +2203,7 @@ fn test_bitlist_bitlist_16_nil_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2211,7 +2211,7 @@ fn test_bitlist_bitlist_16_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_1() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_nil_1/serialized.ssz_snappy",
@@ -2221,7 +2221,7 @@ fn test_bitlist_bitlist_1_nil_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2229,7 +2229,7 @@ fn test_bitlist_bitlist_1_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_1() {
-    let value = Bitlist::<5>::from_iter([true, true, true]);
+    let mut value = Bitlist::<5>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_max_1/serialized.ssz_snappy",
@@ -2239,7 +2239,7 @@ fn test_bitlist_bitlist_5_max_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -2247,7 +2247,7 @@ fn test_bitlist_bitlist_5_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_0() {
-    let value = Bitlist::<8>::from_iter([false, true, true, true, false, false, true, true]);
+    let mut value = Bitlist::<8>::from_iter([false, true, true, true, false, false, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_lengthy_0/serialized.ssz_snappy",
@@ -2257,7 +2257,7 @@ fn test_bitlist_bitlist_8_lengthy_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("095847dd477b5ac2b2a5930d0633975f09e835630c2d4a832b6469e8c0d106d1");
     assert_eq!(root, expected_root);
@@ -2265,7 +2265,7 @@ fn test_bitlist_bitlist_8_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_2() {
-    let value = Bitlist::<8>::from_iter([]);
+    let mut value = Bitlist::<8>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_nil_2/serialized.ssz_snappy",
@@ -2275,7 +2275,7 @@ fn test_bitlist_bitlist_8_nil_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2283,7 +2283,7 @@ fn test_bitlist_bitlist_8_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_1() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -2321,7 +2321,7 @@ fn test_bitlist_bitlist_512_max_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ca6250f3556974d64650a327c0551859f706d9778399caff8a6be920d88fb39f");
     assert_eq!(root, expected_root);
@@ -2329,7 +2329,7 @@ fn test_bitlist_bitlist_512_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_4() {
-    let value = Bitlist::<5>::from_iter([false, true, true, false]);
+    let mut value = Bitlist::<5>::from_iter([false, true, true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_random_4/serialized.ssz_snappy",
@@ -2339,7 +2339,7 @@ fn test_bitlist_bitlist_5_random_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("894e8a2ce460c6c6ba12d467634e6c34ce2a1b58d0c6dfe3d98b532898c58611");
     assert_eq!(root, expected_root);
@@ -2347,7 +2347,7 @@ fn test_bitlist_bitlist_5_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_4() {
-    let value = Bitlist::<4>::from_iter([false, false]);
+    let mut value = Bitlist::<4>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_random_4/serialized.ssz_snappy",
@@ -2357,7 +2357,7 @@ fn test_bitlist_bitlist_4_random_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -2365,7 +2365,7 @@ fn test_bitlist_bitlist_4_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_0() {
-    let value = Bitlist::<31>::from_iter([false]);
+    let mut value = Bitlist::<31>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_random_0/serialized.ssz_snappy",
@@ -2375,7 +2375,7 @@ fn test_bitlist_bitlist_31_random_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -2383,7 +2383,7 @@ fn test_bitlist_bitlist_31_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_2() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         false, false, false, false, false, false, false, false, false, false,
     ]);
     let encoding = serialize(&value);
@@ -2395,7 +2395,7 @@ fn test_bitlist_bitlist_16_zero_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b04cc2cb8ea6754f94c2e7403cf58e20c9023a98350c84282966e0bd6729d3ca");
     assert_eq!(root, expected_root);
@@ -2403,7 +2403,7 @@ fn test_bitlist_bitlist_16_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_1() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_nil_1/serialized.ssz_snappy",
@@ -2413,7 +2413,7 @@ fn test_bitlist_bitlist_3_nil_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2421,7 +2421,7 @@ fn test_bitlist_bitlist_3_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_3() {
-    let value = Bitlist::<4>::from_iter([false]);
+    let mut value = Bitlist::<4>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_random_3/serialized.ssz_snappy",
@@ -2431,7 +2431,7 @@ fn test_bitlist_bitlist_4_random_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -2439,7 +2439,7 @@ fn test_bitlist_bitlist_4_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_1() {
-    let value = Bitlist::<5>::from_iter([true, false, false, true, true]);
+    let mut value = Bitlist::<5>::from_iter([true, false, false, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_lengthy_1/serialized.ssz_snappy",
@@ -2449,7 +2449,7 @@ fn test_bitlist_bitlist_5_lengthy_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7000b9bd26fb753d24a4ed870faee659894843b795377a89ade25b649246e773");
     assert_eq!(root, expected_root);
@@ -2457,7 +2457,7 @@ fn test_bitlist_bitlist_5_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_3() {
-    let value = Bitlist::<5>::from_iter([false, true]);
+    let mut value = Bitlist::<5>::from_iter([false, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_random_3/serialized.ssz_snappy",
@@ -2467,7 +2467,7 @@ fn test_bitlist_bitlist_5_random_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0e01f8d9a6720610a44a70c2c91bbe750ec6cd67892d92b1016394abfc382cf9");
     assert_eq!(root, expected_root);
@@ -2475,7 +2475,7 @@ fn test_bitlist_bitlist_5_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_0() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_zero_0/serialized.ssz_snappy",
@@ -2485,7 +2485,7 @@ fn test_bitlist_bitlist_1_zero_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2493,7 +2493,7 @@ fn test_bitlist_bitlist_1_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_0() {
-    let value = Bitlist::<5>::from_iter([true, true, true]);
+    let mut value = Bitlist::<5>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_max_0/serialized.ssz_snappy",
@@ -2503,7 +2503,7 @@ fn test_bitlist_bitlist_5_max_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -2511,7 +2511,7 @@ fn test_bitlist_bitlist_5_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_0() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_nil_0/serialized.ssz_snappy",
@@ -2521,7 +2521,7 @@ fn test_bitlist_bitlist_1_nil_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2529,7 +2529,7 @@ fn test_bitlist_bitlist_1_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_4() {
-    let value = Bitlist::<16>::from_iter([]);
+    let mut value = Bitlist::<16>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_nil_4/serialized.ssz_snappy",
@@ -2539,7 +2539,7 @@ fn test_bitlist_bitlist_16_nil_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2547,7 +2547,7 @@ fn test_bitlist_bitlist_16_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_3() {
-    let value = Bitlist::<16>::from_iter([]);
+    let mut value = Bitlist::<16>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_nil_3/serialized.ssz_snappy",
@@ -2557,7 +2557,7 @@ fn test_bitlist_bitlist_16_nil_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2565,7 +2565,7 @@ fn test_bitlist_bitlist_16_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_4() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_max_4/serialized.ssz_snappy",
@@ -2575,7 +2575,7 @@ fn test_bitlist_bitlist_2_max_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2583,7 +2583,7 @@ fn test_bitlist_bitlist_2_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_0() {
-    let value = Bitlist::<4>::from_iter([false, false, false, false]);
+    let mut value = Bitlist::<4>::from_iter([false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_zero_0/serialized.ssz_snappy",
@@ -2593,7 +2593,7 @@ fn test_bitlist_bitlist_4_zero_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);
@@ -2601,7 +2601,7 @@ fn test_bitlist_bitlist_4_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_3() {
-    let value = Bitlist::<2>::from_iter([true]);
+    let mut value = Bitlist::<2>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_max_3/serialized.ssz_snappy",
@@ -2611,7 +2611,7 @@ fn test_bitlist_bitlist_2_max_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -2619,7 +2619,7 @@ fn test_bitlist_bitlist_2_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_3() {
-    let value = Bitlist::<513>::from_iter([]);
+    let mut value = Bitlist::<513>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_513_nil_3/serialized.ssz_snappy",
@@ -2629,7 +2629,7 @@ fn test_bitlist_bitlist_513_nil_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -2637,7 +2637,7 @@ fn test_bitlist_bitlist_513_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_3() {
-    let value = Bitlist::<2>::from_iter([true, false]);
+    let mut value = Bitlist::<2>::from_iter([true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_lengthy_3/serialized.ssz_snappy",
@@ -2647,7 +2647,7 @@ fn test_bitlist_bitlist_2_lengthy_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff55c97976a840b4ced964ed49e3794594ba3f675238b5fd25d282b60f70a194");
     assert_eq!(root, expected_root);
@@ -2655,7 +2655,7 @@ fn test_bitlist_bitlist_2_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_4() {
-    let value = Bitlist::<513>::from_iter([]);
+    let mut value = Bitlist::<513>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_513_nil_4/serialized.ssz_snappy",
@@ -2665,7 +2665,7 @@ fn test_bitlist_bitlist_513_nil_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -2673,7 +2673,7 @@ fn test_bitlist_bitlist_513_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_2() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         true, false, false, false, false, true, false, false, false, true, false, true, true,
         false, true, true, false, true, true, false, false, true, false, true, true, true, true,
         true, false, false, false, false, true, false, false, true, true, true, true, true, true,
@@ -2721,7 +2721,7 @@ fn test_bitlist_bitlist_513_lengthy_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fcc1fb245d5eae1370c4cfaf51a23a68d24fc931eb75d8e3b337eadf1c94b4be");
     assert_eq!(root, expected_root);
@@ -2729,7 +2729,7 @@ fn test_bitlist_bitlist_513_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_2() {
-    let value = Bitlist::<5>::from_iter([false, false, false, false]);
+    let mut value = Bitlist::<5>::from_iter([false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_zero_2/serialized.ssz_snappy",
@@ -2739,7 +2739,7 @@ fn test_bitlist_bitlist_5_zero_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);
@@ -2747,7 +2747,7 @@ fn test_bitlist_bitlist_5_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_4() {
-    let value = Bitlist::<2>::from_iter([true, false]);
+    let mut value = Bitlist::<2>::from_iter([true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_lengthy_4/serialized.ssz_snappy",
@@ -2757,7 +2757,7 @@ fn test_bitlist_bitlist_2_lengthy_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff55c97976a840b4ced964ed49e3794594ba3f675238b5fd25d282b60f70a194");
     assert_eq!(root, expected_root);
@@ -2765,7 +2765,7 @@ fn test_bitlist_bitlist_2_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_0() {
-    let value = Bitlist::<8>::from_iter([false, false, false, false, false, false]);
+    let mut value = Bitlist::<8>::from_iter([false, false, false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_zero_0/serialized.ssz_snappy",
@@ -2775,7 +2775,7 @@ fn test_bitlist_bitlist_8_zero_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7d360196d14b15261c9e5f576df8dc8b48d18d79b4198f167741052747704352");
     assert_eq!(root, expected_root);
@@ -2783,7 +2783,7 @@ fn test_bitlist_bitlist_8_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_random_0() {
-    let value = Bitlist::<8>::from_iter([true, true, true, true, false, false]);
+    let mut value = Bitlist::<8>::from_iter([true, true, true, true, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_random_0/serialized.ssz_snappy",
@@ -2793,7 +2793,7 @@ fn test_bitlist_bitlist_8_random_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("385e8de0fb7865579bcaf9d0a9c86e4cca08a6911d1ce85530f96ce202a38d21");
     assert_eq!(root, expected_root);
@@ -2801,7 +2801,7 @@ fn test_bitlist_bitlist_8_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_4() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         false, true, true, true, false, true, false, false, true, false, false, false, false,
         false, false, true, false, true, false, false, true, false, true, true, false, true, false,
         false, false, true, false,
@@ -2815,7 +2815,7 @@ fn test_bitlist_bitlist_31_lengthy_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("152b52ebbfc701c7a39758748e1f14b4361ae37dd480b6914aa725824cde97f2");
     assert_eq!(root, expected_root);
@@ -2823,7 +2823,7 @@ fn test_bitlist_bitlist_31_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_1() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_random_1/serialized.ssz_snappy",
@@ -2833,7 +2833,7 @@ fn test_bitlist_bitlist_3_random_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2841,7 +2841,7 @@ fn test_bitlist_bitlist_3_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_1() {
-    let value = Bitlist::<2>::from_iter([false, true]);
+    let mut value = Bitlist::<2>::from_iter([false, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_random_1/serialized.ssz_snappy",
@@ -2851,7 +2851,7 @@ fn test_bitlist_bitlist_2_random_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0e01f8d9a6720610a44a70c2c91bbe750ec6cd67892d92b1016394abfc382cf9");
     assert_eq!(root, expected_root);
@@ -2859,7 +2859,7 @@ fn test_bitlist_bitlist_2_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_1() {
-    let value = Bitlist::<16>::from_iter([false, false]);
+    let mut value = Bitlist::<16>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_random_1/serialized.ssz_snappy",
@@ -2869,7 +2869,7 @@ fn test_bitlist_bitlist_16_random_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -2877,7 +2877,7 @@ fn test_bitlist_bitlist_16_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_3() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         false, false, true, true, true, true, false, true, true, true, true, false, false, false,
         true, false, false, true, true, true, false, false, false, false, false, true, true, true,
         true, false, false,
@@ -2891,7 +2891,7 @@ fn test_bitlist_bitlist_31_lengthy_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0faa1049c965bf5a37db3b457dcc3a2ee179ef704c42a29722641b2ec3bb3658");
     assert_eq!(root, expected_root);
@@ -2899,7 +2899,7 @@ fn test_bitlist_bitlist_31_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_2() {
-    let value = Bitlist::<4>::from_iter([]);
+    let mut value = Bitlist::<4>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_nil_2/serialized.ssz_snappy",
@@ -2909,7 +2909,7 @@ fn test_bitlist_bitlist_4_nil_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2917,7 +2917,7 @@ fn test_bitlist_bitlist_4_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_0() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
     ]);
     let encoding = serialize(&value);
@@ -2929,7 +2929,7 @@ fn test_bitlist_bitlist_31_max_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ebe018d5287ea5be7d789946da9587c27f5dd82d8c120a594ae0e8ddd2e21802");
     assert_eq!(root, expected_root);
@@ -2937,7 +2937,7 @@ fn test_bitlist_bitlist_31_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_3() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, false, true, false, true, true, true, true, false, false, true, false, true, true,
         true, false, true, false, true, true, true, true, true, false, false, true, true, false,
         true, true, true, true, true, false, false, true, true, true, false, true, false, true,
@@ -2986,7 +2986,7 @@ fn test_bitlist_bitlist_513_lengthy_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("eb5acc36387e3d3e44187bd6c086e4409fab204daa33ad40a99226dd2c487d8e");
     assert_eq!(root, expected_root);
@@ -2994,7 +2994,7 @@ fn test_bitlist_bitlist_513_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_3() {
-    let value = Bitlist::<5>::from_iter([false]);
+    let mut value = Bitlist::<5>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_zero_3/serialized.ssz_snappy",
@@ -3004,7 +3004,7 @@ fn test_bitlist_bitlist_5_zero_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -3012,7 +3012,7 @@ fn test_bitlist_bitlist_5_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_1() {
-    let value = Bitlist::<8>::from_iter([false, false]);
+    let mut value = Bitlist::<8>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_zero_1/serialized.ssz_snappy",
@@ -3022,7 +3022,7 @@ fn test_bitlist_bitlist_8_zero_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -3030,7 +3030,7 @@ fn test_bitlist_bitlist_8_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_2() {
-    let value = Bitlist::<513>::from_iter([]);
+    let mut value = Bitlist::<513>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_513_nil_2/serialized.ssz_snappy",
@@ -3040,7 +3040,7 @@ fn test_bitlist_bitlist_513_nil_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -3048,7 +3048,7 @@ fn test_bitlist_bitlist_513_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_4() {
-    let value = Bitlist::<5>::from_iter([false, false, false, false]);
+    let mut value = Bitlist::<5>::from_iter([false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_zero_4/serialized.ssz_snappy",
@@ -3058,7 +3058,7 @@ fn test_bitlist_bitlist_5_zero_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);
@@ -3066,7 +3066,7 @@ fn test_bitlist_bitlist_5_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_4() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         true, false, true, true, true, true, false, false, true, false, true, true, true, false,
         true, false, true, false, true, true, false, true, true, false, true, true, true, true,
         false, true, true, true, false, false, false, true, true, true, true, true, true, false,
@@ -3115,7 +3115,7 @@ fn test_bitlist_bitlist_513_lengthy_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4edc0e0f8cb3511f8e89e5a9d73fdd50270e49aa8bfa62ffe8c8e99c161e76ba");
     assert_eq!(root, expected_root);
@@ -3123,7 +3123,7 @@ fn test_bitlist_bitlist_513_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_2() {
-    let value = Bitlist::<2>::from_iter([true, true]);
+    let mut value = Bitlist::<2>::from_iter([true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_lengthy_2/serialized.ssz_snappy",
@@ -3133,7 +3133,7 @@ fn test_bitlist_bitlist_2_lengthy_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -3141,7 +3141,7 @@ fn test_bitlist_bitlist_2_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_2() {
-    let value = Bitlist::<2>::from_iter([true]);
+    let mut value = Bitlist::<2>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_max_2/serialized.ssz_snappy",
@@ -3151,7 +3151,7 @@ fn test_bitlist_bitlist_2_max_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -3159,7 +3159,7 @@ fn test_bitlist_bitlist_2_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_1() {
-    let value = Bitlist::<4>::from_iter([false]);
+    let mut value = Bitlist::<4>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_zero_1/serialized.ssz_snappy",
@@ -3169,7 +3169,7 @@ fn test_bitlist_bitlist_4_zero_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -3177,7 +3177,7 @@ fn test_bitlist_bitlist_4_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_4() {
-    let value = Bitlist::<4>::from_iter([]);
+    let mut value = Bitlist::<4>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_nil_4/serialized.ssz_snappy",
@@ -3187,7 +3187,7 @@ fn test_bitlist_bitlist_4_nil_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3195,7 +3195,7 @@ fn test_bitlist_bitlist_4_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_3() {
-    let value = Bitlist::<4>::from_iter([]);
+    let mut value = Bitlist::<4>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_nil_3/serialized.ssz_snappy",
@@ -3205,7 +3205,7 @@ fn test_bitlist_bitlist_4_nil_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3213,7 +3213,7 @@ fn test_bitlist_bitlist_4_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_1() {
-    let value = Bitlist::<31>::from_iter([true]);
+    let mut value = Bitlist::<31>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_max_1/serialized.ssz_snappy",
@@ -3223,7 +3223,7 @@ fn test_bitlist_bitlist_31_max_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -3231,7 +3231,7 @@ fn test_bitlist_bitlist_31_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_0() {
-    let value =
+    let mut value =
         Bitlist::<16>::from_iter([false, false, true, false, true, true, false, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3242,7 +3242,7 @@ fn test_bitlist_bitlist_16_random_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("eec57ef94d128f67c545a95b84f97501237ed672f583769110409b2df50bce84");
     assert_eq!(root, expected_root);
@@ -3250,7 +3250,7 @@ fn test_bitlist_bitlist_16_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_2() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         true, false, true, false, true, false, false, true, false, true, false, false, true, false,
         false, true, true, true, false, false, true, false, true, false, false, false, true, true,
         false, false, true,
@@ -3264,7 +3264,7 @@ fn test_bitlist_bitlist_31_lengthy_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("57bdf36005bb9113c2b89db95c10946d97609b3173d4397a1a74755d0c6490f8");
     assert_eq!(root, expected_root);
@@ -3272,7 +3272,7 @@ fn test_bitlist_bitlist_31_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_8_random_1() {
-    let value = Bitlist::<8>::from_iter([false, false]);
+    let mut value = Bitlist::<8>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_random_1/serialized.ssz_snappy",
@@ -3282,7 +3282,7 @@ fn test_bitlist_bitlist_8_random_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -3290,7 +3290,7 @@ fn test_bitlist_bitlist_8_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_0() {
-    let value = Bitlist::<3>::from_iter([false, false]);
+    let mut value = Bitlist::<3>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_random_0/serialized.ssz_snappy",
@@ -3300,7 +3300,7 @@ fn test_bitlist_bitlist_3_random_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -3308,7 +3308,7 @@ fn test_bitlist_bitlist_3_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_0() {
-    let value = Bitlist::<2>::from_iter([true]);
+    let mut value = Bitlist::<2>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_random_0/serialized.ssz_snappy",
@@ -3318,7 +3318,7 @@ fn test_bitlist_bitlist_2_random_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -3326,7 +3326,7 @@ fn test_bitlist_bitlist_2_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_3() {
-    let value = Bitlist::<4>::from_iter([true, true, true, true]);
+    let mut value = Bitlist::<4>::from_iter([true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_max_3/serialized.ssz_snappy",
@@ -3336,7 +3336,7 @@ fn test_bitlist_bitlist_4_max_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4b07c3799db025f3aa92ced1e8545367a2b6e44960f479d3f9d62b61812892d5");
     assert_eq!(root, expected_root);
@@ -3344,7 +3344,7 @@ fn test_bitlist_bitlist_4_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_3() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_random_3/serialized.ssz_snappy",
@@ -3354,7 +3354,7 @@ fn test_bitlist_bitlist_1_random_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3362,7 +3362,7 @@ fn test_bitlist_bitlist_1_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_1() {
-    let value = Bitlist::<31>::from_iter([]);
+    let mut value = Bitlist::<31>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_nil_1/serialized.ssz_snappy",
@@ -3372,7 +3372,7 @@ fn test_bitlist_bitlist_31_nil_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3380,7 +3380,7 @@ fn test_bitlist_bitlist_31_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_4() {
-    let value = Bitlist::<4>::from_iter([true, true]);
+    let mut value = Bitlist::<4>::from_iter([true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_max_4/serialized.ssz_snappy",
@@ -3390,7 +3390,7 @@ fn test_bitlist_bitlist_4_max_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -3398,7 +3398,7 @@ fn test_bitlist_bitlist_4_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_4() {
-    let value = Bitlist::<1>::from_iter([true]);
+    let mut value = Bitlist::<1>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_random_4/serialized.ssz_snappy",
@@ -3408,7 +3408,7 @@ fn test_bitlist_bitlist_1_random_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -3416,7 +3416,7 @@ fn test_bitlist_bitlist_1_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_2() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_nil_2/serialized.ssz_snappy",
@@ -3426,7 +3426,7 @@ fn test_bitlist_bitlist_2_nil_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3434,7 +3434,7 @@ fn test_bitlist_bitlist_2_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_2() {
-    let value = Bitlist::<513>::from_iter([true, true, true, true, true, true, true, true]);
+    let mut value = Bitlist::<513>::from_iter([true, true, true, true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_513_max_2/serialized.ssz_snappy",
@@ -3444,7 +3444,7 @@ fn test_bitlist_bitlist_513_max_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("848557322ff06141bbb7ac657b15c24e6300986a5ff8ce878ef4b198c0bd51b0");
     assert_eq!(root, expected_root);
@@ -3452,7 +3452,7 @@ fn test_bitlist_bitlist_513_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_3() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         true, false, false, true, false, false, false, true, true, true, false, false, false,
         false, false, false,
     ]);
@@ -3465,7 +3465,7 @@ fn test_bitlist_bitlist_16_lengthy_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("50fea858f788bbc2f17f809e05682bf855493a7b8c594f4c2342b469ac7bdb53");
     assert_eq!(root, expected_root);
@@ -3473,7 +3473,7 @@ fn test_bitlist_bitlist_16_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_4() {
-    let value = Bitlist::<4>::from_iter([false, true, true, false]);
+    let mut value = Bitlist::<4>::from_iter([false, true, true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_lengthy_4/serialized.ssz_snappy",
@@ -3483,7 +3483,7 @@ fn test_bitlist_bitlist_4_lengthy_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("894e8a2ce460c6c6ba12d467634e6c34ce2a1b58d0c6dfe3d98b532898c58611");
     assert_eq!(root, expected_root);
@@ -3491,7 +3491,7 @@ fn test_bitlist_bitlist_4_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_3() {
-    let value = Bitlist::<4>::from_iter([true, false, false, false]);
+    let mut value = Bitlist::<4>::from_iter([true, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_lengthy_3/serialized.ssz_snappy",
@@ -3501,7 +3501,7 @@ fn test_bitlist_bitlist_4_lengthy_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f9c5ada16029ed1580188989686f19e749c006b2eac37d3ef087b824b31ba997");
     assert_eq!(root, expected_root);
@@ -3509,7 +3509,7 @@ fn test_bitlist_bitlist_4_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_4() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         false, true, true, true, true, false, false, false, true, false, false, false, true, false,
         true, true,
     ]);
@@ -3522,7 +3522,7 @@ fn test_bitlist_bitlist_16_lengthy_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("983039dcf7ee961e2a2c1b1d0b57ad04491b8674c0f9f6dc326244e48dacd851");
     assert_eq!(root, expected_root);
@@ -3530,7 +3530,7 @@ fn test_bitlist_bitlist_16_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_2() {
-    let value = Bitlist::<4>::from_iter([]);
+    let mut value = Bitlist::<4>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_max_2/serialized.ssz_snappy",
@@ -3540,7 +3540,7 @@ fn test_bitlist_bitlist_4_max_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3548,7 +3548,7 @@ fn test_bitlist_bitlist_4_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_2() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_random_2/serialized.ssz_snappy",
@@ -3558,7 +3558,7 @@ fn test_bitlist_bitlist_1_random_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3566,7 +3566,7 @@ fn test_bitlist_bitlist_1_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_0() {
-    let value = Bitlist::<31>::from_iter([]);
+    let mut value = Bitlist::<31>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_nil_0/serialized.ssz_snappy",
@@ -3576,7 +3576,7 @@ fn test_bitlist_bitlist_31_nil_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3584,7 +3584,7 @@ fn test_bitlist_bitlist_31_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_4() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -3603,7 +3603,7 @@ fn test_bitlist_bitlist_513_max_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e05d10ac23b945573dca5263c13a7eaf50854397bf48f920175a10509bf65ecf");
     assert_eq!(root, expected_root);
@@ -3611,7 +3611,7 @@ fn test_bitlist_bitlist_513_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_2() {
-    let value = Bitlist::<4>::from_iter([true, true, true, false]);
+    let mut value = Bitlist::<4>::from_iter([true, true, true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_lengthy_2/serialized.ssz_snappy",
@@ -3621,7 +3621,7 @@ fn test_bitlist_bitlist_4_lengthy_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("374bd7c88680671ad4be6e1b576db80646d992d893a5eeb1d1d0f403c3331b32");
     assert_eq!(root, expected_root);
@@ -3629,7 +3629,7 @@ fn test_bitlist_bitlist_4_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_3() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -3665,7 +3665,7 @@ fn test_bitlist_bitlist_513_max_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a575735c9960d438c8bdd59d05fedefce22f8e5b77b09efb5b4e9942b847468e");
     assert_eq!(root, expected_root);
@@ -3673,7 +3673,7 @@ fn test_bitlist_bitlist_513_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_2() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         true, false, false, false, false, true, false, true, true, true, true, false, true, false,
         false, true,
     ]);
@@ -3686,7 +3686,7 @@ fn test_bitlist_bitlist_16_lengthy_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fc0027195d4d241e8d3111d41d749a46f62e2d0e78aa503b856774abe6b7e6c3");
     assert_eq!(root, expected_root);
@@ -3694,7 +3694,7 @@ fn test_bitlist_bitlist_16_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_3() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_nil_3/serialized.ssz_snappy",
@@ -3704,7 +3704,7 @@ fn test_bitlist_bitlist_2_nil_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3712,7 +3712,7 @@ fn test_bitlist_bitlist_2_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_4() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_nil_4/serialized.ssz_snappy",
@@ -3722,7 +3722,7 @@ fn test_bitlist_bitlist_2_nil_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3730,7 +3730,7 @@ fn test_bitlist_bitlist_2_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_3() {
-    let value = Bitlist::<3>::from_iter([false, false, true]);
+    let mut value = Bitlist::<3>::from_iter([false, false, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_lengthy_3/serialized.ssz_snappy",
@@ -3740,7 +3740,7 @@ fn test_bitlist_bitlist_3_lengthy_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d3156136ef0ebd0cb8945f7c18cfe8ad539d08d8703744bc11371e49e6a4d9ad");
     assert_eq!(root, expected_root);
@@ -3748,7 +3748,7 @@ fn test_bitlist_bitlist_3_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_2() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         true, false, false, false, false, true, false, true, false, true, true, false, true, true,
         false, false, false, false, false, false, false, true, true, true, true, false, true, true,
         true, false, false, false, false, true, false, true, true, true, true, true, true, true,
@@ -3797,7 +3797,7 @@ fn test_bitlist_bitlist_512_lengthy_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("04d0ff41239e5365cafa09c58dedb823eb13cb4912afea9fc26a658b955a4594");
     assert_eq!(root, expected_root);
@@ -3805,7 +3805,7 @@ fn test_bitlist_bitlist_512_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_2() {
-    let value = Bitlist::<3>::from_iter([true]);
+    let mut value = Bitlist::<3>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_max_2/serialized.ssz_snappy",
@@ -3815,7 +3815,7 @@ fn test_bitlist_bitlist_3_max_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -3823,7 +3823,7 @@ fn test_bitlist_bitlist_3_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_0() {
-    let value = Bitlist::<1>::from_iter([true]);
+    let mut value = Bitlist::<1>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_lengthy_0/serialized.ssz_snappy",
@@ -3833,7 +3833,7 @@ fn test_bitlist_bitlist_1_lengthy_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -3841,7 +3841,7 @@ fn test_bitlist_bitlist_1_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_4() {
-    let value = Bitlist::<3>::from_iter([true, true, true]);
+    let mut value = Bitlist::<3>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_lengthy_4/serialized.ssz_snappy",
@@ -3851,7 +3851,7 @@ fn test_bitlist_bitlist_3_lengthy_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -3859,7 +3859,7 @@ fn test_bitlist_bitlist_3_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_1() {
-    let value = Bitlist::<8>::from_iter([true, true, true, true, true, true, true, true]);
+    let mut value = Bitlist::<8>::from_iter([true, true, true, true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_max_1/serialized.ssz_snappy",
@@ -3869,7 +3869,7 @@ fn test_bitlist_bitlist_8_max_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("017d2fa0f6934ed2354e4cdb7a2230ccf8f31fe758c7a47442e37fdea1d68bfe");
     assert_eq!(root, expected_root);
@@ -3877,7 +3877,7 @@ fn test_bitlist_bitlist_8_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_2() {
-    let value = Bitlist::<512>::from_iter([]);
+    let mut value = Bitlist::<512>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_512_nil_2/serialized.ssz_snappy",
@@ -3887,7 +3887,7 @@ fn test_bitlist_bitlist_512_nil_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -3895,7 +3895,7 @@ fn test_bitlist_bitlist_512_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_3() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false,
@@ -3909,7 +3909,7 @@ fn test_bitlist_bitlist_31_zero_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("04997ec49450b710d4d92e2e6e92c47b193b0ec6f841d7d692bf0f410cbc7269");
     assert_eq!(root, expected_root);
@@ -3917,7 +3917,7 @@ fn test_bitlist_bitlist_31_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_4() {
-    let value = Bitlist::<31>::from_iter([false, false]);
+    let mut value = Bitlist::<31>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_zero_4/serialized.ssz_snappy",
@@ -3927,7 +3927,7 @@ fn test_bitlist_bitlist_31_zero_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -3935,7 +3935,7 @@ fn test_bitlist_bitlist_31_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_2() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         true, true, true, false, true, true, false, false, false, false, true, false, true, false,
         true, true, true, false, false, false, true, true, true, true, false, false, true, false,
         false, true, true, false, false, true, false, true, false, true, true, true, false, false,
@@ -3970,7 +3970,7 @@ fn test_bitlist_bitlist_512_random_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0885e8d339f7016801875ef256eb180be417810e6151703137877f68926952f5");
     assert_eq!(root, expected_root);
@@ -3978,7 +3978,7 @@ fn test_bitlist_bitlist_512_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_2() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, true, false, true, true, true, false, true, true, true, true, true, false, false,
         true, false, true, false, true, false, false, true, true, true, true, true, false, false,
         false, true, true, false, true, false, false, false, false, true, true, true, false, true,
@@ -4020,7 +4020,7 @@ fn test_bitlist_bitlist_513_random_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("bb76eb1bab23fc2865c84717251e4305221771924259082d793d3bbaa6444ba1");
     assert_eq!(root, expected_root);
@@ -4028,7 +4028,7 @@ fn test_bitlist_bitlist_513_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_3() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -4051,7 +4051,7 @@ fn test_bitlist_bitlist_513_zero_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("54bfe2c647e52bf3897cff9675165d53f277e1f7dbd7c620f630a2deb02ce0c8");
     assert_eq!(root, expected_root);
@@ -4059,7 +4059,7 @@ fn test_bitlist_bitlist_513_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_4() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_zero_4/serialized.ssz_snappy",
@@ -4069,7 +4069,7 @@ fn test_bitlist_bitlist_3_zero_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4077,7 +4077,7 @@ fn test_bitlist_bitlist_3_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_3() {
-    let value = Bitlist::<1>::from_iter([true]);
+    let mut value = Bitlist::<1>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_max_3/serialized.ssz_snappy",
@@ -4087,7 +4087,7 @@ fn test_bitlist_bitlist_1_max_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -4095,7 +4095,7 @@ fn test_bitlist_bitlist_1_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_4() {
-    let value = Bitlist::<1>::from_iter([true]);
+    let mut value = Bitlist::<1>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_max_4/serialized.ssz_snappy",
@@ -4105,7 +4105,7 @@ fn test_bitlist_bitlist_1_max_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -4113,7 +4113,7 @@ fn test_bitlist_bitlist_1_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_3() {
-    let value = Bitlist::<3>::from_iter([false, false, false]);
+    let mut value = Bitlist::<3>::from_iter([false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_zero_3/serialized.ssz_snappy",
@@ -4123,7 +4123,7 @@ fn test_bitlist_bitlist_3_zero_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d86ae2ca925345bf2412bde450ac175742d979c1ea7b961bd1efe10beb9500cf");
     assert_eq!(root, expected_root);
@@ -4131,7 +4131,7 @@ fn test_bitlist_bitlist_3_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_4() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -4164,7 +4164,7 @@ fn test_bitlist_bitlist_513_zero_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9b7d4ffa3720c8ea2c66e59f1890a83c86ef2b4442a5ebe6d757fb4cbe0b3231");
     assert_eq!(root, expected_root);
@@ -4172,7 +4172,7 @@ fn test_bitlist_bitlist_513_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_0() {
-    let value = Bitlist::<16>::from_iter([true, true, true, true, true, true, true, true]);
+    let mut value = Bitlist::<16>::from_iter([true, true, true, true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_max_0/serialized.ssz_snappy",
@@ -4182,7 +4182,7 @@ fn test_bitlist_bitlist_16_max_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("017d2fa0f6934ed2354e4cdb7a2230ccf8f31fe758c7a47442e37fdea1d68bfe");
     assert_eq!(root, expected_root);
@@ -4190,7 +4190,7 @@ fn test_bitlist_bitlist_16_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_1() {
-    let value = Bitlist::<2>::from_iter([]);
+    let mut value = Bitlist::<2>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_zero_1/serialized.ssz_snappy",
@@ -4200,7 +4200,7 @@ fn test_bitlist_bitlist_2_zero_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4208,7 +4208,7 @@ fn test_bitlist_bitlist_2_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_3() {
-    let value = Bitlist::<5>::from_iter([]);
+    let mut value = Bitlist::<5>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_nil_3/serialized.ssz_snappy",
@@ -4218,7 +4218,7 @@ fn test_bitlist_bitlist_5_nil_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4226,7 +4226,7 @@ fn test_bitlist_bitlist_5_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_4() {
-    let value = Bitlist::<5>::from_iter([]);
+    let mut value = Bitlist::<5>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_nil_4/serialized.ssz_snappy",
@@ -4236,7 +4236,7 @@ fn test_bitlist_bitlist_5_nil_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4244,7 +4244,7 @@ fn test_bitlist_bitlist_5_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_1() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -4291,7 +4291,7 @@ fn test_bitlist_bitlist_512_zero_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4d8dddd9769fcea91305afd9f96b9b187ad7dbd994a67cea4eeb7e2c0348c292");
     assert_eq!(root, expected_root);
@@ -4299,7 +4299,7 @@ fn test_bitlist_bitlist_512_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_4() {
-    let value = Bitlist::<512>::from_iter([]);
+    let mut value = Bitlist::<512>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_512_nil_4/serialized.ssz_snappy",
@@ -4309,7 +4309,7 @@ fn test_bitlist_bitlist_512_nil_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -4317,7 +4317,7 @@ fn test_bitlist_bitlist_512_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_3() {
-    let value = Bitlist::<512>::from_iter([]);
+    let mut value = Bitlist::<512>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_512_nil_3/serialized.ssz_snappy",
@@ -4327,7 +4327,7 @@ fn test_bitlist_bitlist_512_nil_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -4335,7 +4335,7 @@ fn test_bitlist_bitlist_512_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_0() {
-    let value = Bitlist::<8>::from_iter([true, true, true, true, true, true, true, true]);
+    let mut value = Bitlist::<8>::from_iter([true, true, true, true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_max_0/serialized.ssz_snappy",
@@ -4345,7 +4345,7 @@ fn test_bitlist_bitlist_8_max_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("017d2fa0f6934ed2354e4cdb7a2230ccf8f31fe758c7a47442e37fdea1d68bfe");
     assert_eq!(root, expected_root);
@@ -4353,7 +4353,7 @@ fn test_bitlist_bitlist_8_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_2() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false,
     ]);
@@ -4366,7 +4366,7 @@ fn test_bitlist_bitlist_31_zero_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("967293ee9d7ba679c3ef076bef139e2ceb96d45d19a624cc59bb5a3c1649ce38");
     assert_eq!(root, expected_root);
@@ -4374,7 +4374,7 @@ fn test_bitlist_bitlist_31_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_3() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         true, true, true, false, false, false, false, false, true, false, true, true, false, false,
         true, false, true, false, false, false, false, false, true, true, true, false, false,
         false, false, true, true, false, false, true, true, false, false, false, false, false,
@@ -4423,7 +4423,7 @@ fn test_bitlist_bitlist_512_lengthy_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("57d984dd8dc742665160586d43e684d59f48ea2fbf7ff6fc6742cdcf050bea09");
     assert_eq!(root, expected_root);
@@ -4431,7 +4431,7 @@ fn test_bitlist_bitlist_512_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_1() {
-    let value = Bitlist::<1>::from_iter([true]);
+    let mut value = Bitlist::<1>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_lengthy_1/serialized.ssz_snappy",
@@ -4441,7 +4441,7 @@ fn test_bitlist_bitlist_1_lengthy_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -4449,7 +4449,7 @@ fn test_bitlist_bitlist_1_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_3() {
-    let value = Bitlist::<3>::from_iter([true]);
+    let mut value = Bitlist::<3>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_max_3/serialized.ssz_snappy",
@@ -4459,7 +4459,7 @@ fn test_bitlist_bitlist_3_max_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -4467,7 +4467,7 @@ fn test_bitlist_bitlist_3_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_4() {
-    let value = Bitlist::<3>::from_iter([true, true]);
+    let mut value = Bitlist::<3>::from_iter([true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_max_4/serialized.ssz_snappy",
@@ -4477,7 +4477,7 @@ fn test_bitlist_bitlist_3_max_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -4485,7 +4485,7 @@ fn test_bitlist_bitlist_3_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_4() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, true, false, false, true, false, false, false, false, true, false, false, true,
         true, false, false, true, false, true, false, true, true, false, true, true, true, true,
         false, false, true, true, true, false, false, true, false, true, true, true, false, false,
@@ -4534,7 +4534,7 @@ fn test_bitlist_bitlist_512_lengthy_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("28933deb812002abaf34c610f6b2f77cb8acbc617d5a8f8a320ca4813c29fea2");
     assert_eq!(root, expected_root);
@@ -4542,7 +4542,7 @@ fn test_bitlist_bitlist_512_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_2() {
-    let value = Bitlist::<3>::from_iter([true, false, false]);
+    let mut value = Bitlist::<3>::from_iter([true, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_lengthy_2/serialized.ssz_snappy",
@@ -4552,7 +4552,7 @@ fn test_bitlist_bitlist_3_lengthy_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("caea92341df83aa8d4225099f16e86cbf457ec7ea97ccddb4ba5560062eee695");
     assert_eq!(root, expected_root);
@@ -4560,7 +4560,7 @@ fn test_bitlist_bitlist_3_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_0() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -4585,7 +4585,7 @@ fn test_bitlist_bitlist_512_zero_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b9622f5ac7a4f2982e31494019e6fc83a8510ba1313084df18fe74cfd63fff28");
     assert_eq!(root, expected_root);
@@ -4593,7 +4593,7 @@ fn test_bitlist_bitlist_512_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_2() {
-    let value = Bitlist::<5>::from_iter([]);
+    let mut value = Bitlist::<5>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_nil_2/serialized.ssz_snappy",
@@ -4603,7 +4603,7 @@ fn test_bitlist_bitlist_5_nil_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4611,7 +4611,7 @@ fn test_bitlist_bitlist_5_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_0() {
-    let value = Bitlist::<2>::from_iter([false, false]);
+    let mut value = Bitlist::<2>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_2_zero_0/serialized.ssz_snappy",
@@ -4621,7 +4621,7 @@ fn test_bitlist_bitlist_2_zero_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -4629,7 +4629,7 @@ fn test_bitlist_bitlist_2_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_4() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, false, false, true, false, true, true, false, false, false, true, true, false,
         false, true, false, true, false, false, true, true, true, false, true, false, true, false,
         false, true, false, true, false, false, false, false, true, false, false, false, true,
@@ -4648,7 +4648,7 @@ fn test_bitlist_bitlist_513_random_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ba02d7073304a825d35943f503cb081434b0b49713afdff5b5a6ab1f46d14171");
     assert_eq!(root, expected_root);
@@ -4656,7 +4656,7 @@ fn test_bitlist_bitlist_513_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_4() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, false, false, false, false, true, true, false, false, true, true, true, false, true,
         false, false, true, false, false, false, false, false, false, false, true, true, true,
         false, false, false, true, false, false, true, false, true, false, true, true, true, true,
@@ -4697,7 +4697,7 @@ fn test_bitlist_bitlist_512_random_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("813ccb937403bbd02d4ce9cd7e101c3bf3214ed4a1d8c11199288fbcdca45860");
     assert_eq!(root, expected_root);
@@ -4705,7 +4705,7 @@ fn test_bitlist_bitlist_512_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_1() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true,
     ]);
@@ -4718,7 +4718,7 @@ fn test_bitlist_bitlist_16_max_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("dc8212e2404720c98554dfddc81733f88cbbe307a1d4ca5eae4b88e55e382392");
     assert_eq!(root, expected_root);
@@ -4726,7 +4726,7 @@ fn test_bitlist_bitlist_16_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_2() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_zero_2/serialized.ssz_snappy",
@@ -4736,7 +4736,7 @@ fn test_bitlist_bitlist_3_zero_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4744,7 +4744,7 @@ fn test_bitlist_bitlist_3_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_3() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         false, true, false, false, true, true, true, false, false, false, false, true, true, true,
         false, true, false, true, true, false, false, true, true, true, true, true, true, true,
         false, true, false, true, true, false, false, false, true, false, false, false, false,
@@ -4775,7 +4775,7 @@ fn test_bitlist_bitlist_512_random_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0c24b4aa44483bc91415618c8d23fa1ec87cbbf57dd1747ac001513f3ddeea8c");
     assert_eq!(root, expected_root);
@@ -4783,7 +4783,7 @@ fn test_bitlist_bitlist_512_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_3() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, true, false, true, true, false, true, true, false, true, true, false, true, false,
         true, false, false, true, false, false, true, false, true, true, false, true, false, true,
         true, false, true,
@@ -4797,7 +4797,7 @@ fn test_bitlist_bitlist_513_random_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("32370b95731ef776a513ca5ef154a83ba935260f2f4bdbba23c21b33e12f7b62");
     assert_eq!(root, expected_root);
@@ -4805,7 +4805,7 @@ fn test_bitlist_bitlist_513_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_2() {
-    let value = Bitlist::<513>::from_iter([
+    let mut value = Bitlist::<513>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false,
@@ -4819,7 +4819,7 @@ fn test_bitlist_bitlist_513_zero_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("38ab4aeb5726a3fb78af0101063f2586905c3e8466206bfc8777f44ed9e6ef20");
     assert_eq!(root, expected_root);
@@ -4827,7 +4827,7 @@ fn test_bitlist_bitlist_513_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_2() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_max_2/serialized.ssz_snappy",
@@ -4837,7 +4837,7 @@ fn test_bitlist_bitlist_1_max_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4845,7 +4845,7 @@ fn test_bitlist_bitlist_1_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_2() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_nil_2/serialized.ssz_snappy",
@@ -4855,7 +4855,7 @@ fn test_bitlist_bitlist_1_nil_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4863,7 +4863,7 @@ fn test_bitlist_bitlist_1_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_1() {
-    let value = Bitlist::<16>::from_iter([]);
+    let mut value = Bitlist::<16>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_nil_1/serialized.ssz_snappy",
@@ -4873,7 +4873,7 @@ fn test_bitlist_bitlist_16_nil_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4881,7 +4881,7 @@ fn test_bitlist_bitlist_16_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_2() {
-    let value = Bitlist::<5>::from_iter([true, true, true, true]);
+    let mut value = Bitlist::<5>::from_iter([true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_max_2/serialized.ssz_snappy",
@@ -4891,7 +4891,7 @@ fn test_bitlist_bitlist_5_max_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4b07c3799db025f3aa92ced1e8545367a2b6e44960f479d3f9d62b61812892d5");
     assert_eq!(root, expected_root);
@@ -4899,7 +4899,7 @@ fn test_bitlist_bitlist_5_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_4() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_nil_4/serialized.ssz_snappy",
@@ -4909,7 +4909,7 @@ fn test_bitlist_bitlist_3_nil_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4917,7 +4917,7 @@ fn test_bitlist_bitlist_3_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_4() {
-    let value = Bitlist::<5>::from_iter([false, false, false, false, true]);
+    let mut value = Bitlist::<5>::from_iter([false, false, false, false, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_lengthy_4/serialized.ssz_snappy",
@@ -4927,7 +4927,7 @@ fn test_bitlist_bitlist_5_lengthy_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("88b744d02033bbb6a4ebc2dc3f31c4910681596c7bcb9349d9483a33e45899c7");
     assert_eq!(root, expected_root);
@@ -4935,7 +4935,7 @@ fn test_bitlist_bitlist_5_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_3() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_nil_3/serialized.ssz_snappy",
@@ -4945,7 +4945,7 @@ fn test_bitlist_bitlist_3_nil_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4953,7 +4953,7 @@ fn test_bitlist_bitlist_3_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_2() {
-    let value = Bitlist::<31>::from_iter([
+    let mut value = Bitlist::<31>::from_iter([
         false, true, false, true, false, true, true, false, true, false, true, true, false, false,
         false, true, true, false, true, false, true, true, true, false, true, true,
     ]);
@@ -4966,7 +4966,7 @@ fn test_bitlist_bitlist_31_random_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1037ee25750a944efe9b3dc796628f6468a9f242bd791013c439ca785c134482");
     assert_eq!(root, expected_root);
@@ -4974,7 +4974,7 @@ fn test_bitlist_bitlist_31_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_0() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false,
     ]);
@@ -4987,7 +4987,7 @@ fn test_bitlist_bitlist_16_zero_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("69713c9ac33bde909bd8763512e69a7f523d544adcfb8c892e24bc8f6341ea16");
     assert_eq!(root, expected_root);
@@ -4995,7 +4995,7 @@ fn test_bitlist_bitlist_16_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_1() {
-    let value = Bitlist::<4>::from_iter([true, false, false, false]);
+    let mut value = Bitlist::<4>::from_iter([true, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_random_1/serialized.ssz_snappy",
@@ -5005,7 +5005,7 @@ fn test_bitlist_bitlist_4_random_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f9c5ada16029ed1580188989686f19e749c006b2eac37d3ef087b824b31ba997");
     assert_eq!(root, expected_root);
@@ -5013,7 +5013,7 @@ fn test_bitlist_bitlist_4_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_3() {
-    let value = Bitlist::<5>::from_iter([false, true, false, true, true]);
+    let mut value = Bitlist::<5>::from_iter([false, true, false, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_lengthy_3/serialized.ssz_snappy",
@@ -5023,7 +5023,7 @@ fn test_bitlist_bitlist_5_lengthy_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5d40a4acd8c5f8b674c29a7b7814a546fade497a96d0e7bb51c3a4951fb1fa7e");
     assert_eq!(root, expected_root);
@@ -5031,7 +5031,7 @@ fn test_bitlist_bitlist_5_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_2() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_zero_2/serialized.ssz_snappy",
@@ -5041,7 +5041,7 @@ fn test_bitlist_bitlist_1_zero_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5049,7 +5049,7 @@ fn test_bitlist_bitlist_1_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_1() {
-    let value = Bitlist::<5>::from_iter([false, false, false]);
+    let mut value = Bitlist::<5>::from_iter([false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_random_1/serialized.ssz_snappy",
@@ -5059,7 +5059,7 @@ fn test_bitlist_bitlist_5_random_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d86ae2ca925345bf2412bde450ac175742d979c1ea7b961bd1efe10beb9500cf");
     assert_eq!(root, expected_root);
@@ -5067,7 +5067,7 @@ fn test_bitlist_bitlist_5_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_0() {
-    let value = Bitlist::<8>::from_iter([]);
+    let mut value = Bitlist::<8>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_nil_0/serialized.ssz_snappy",
@@ -5077,7 +5077,7 @@ fn test_bitlist_bitlist_8_nil_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5085,7 +5085,7 @@ fn test_bitlist_bitlist_8_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_3() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -5100,7 +5100,7 @@ fn test_bitlist_bitlist_512_max_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8cbf50b584a296a316a71c486b4d4e1fd94edae9bf75f1aff71b8f609dc8352c");
     assert_eq!(root, expected_root);
@@ -5108,7 +5108,7 @@ fn test_bitlist_bitlist_512_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_2() {
-    let value = Bitlist::<8>::from_iter([true, true, false, false, true, false, true, false]);
+    let mut value = Bitlist::<8>::from_iter([true, true, false, false, true, false, true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_lengthy_2/serialized.ssz_snappy",
@@ -5118,7 +5118,7 @@ fn test_bitlist_bitlist_8_lengthy_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("eeb7a380c63f2182c38a556ee4170cb9fd06b86b5014181e7a01ce0097627cf0");
     assert_eq!(root, expected_root);
@@ -5126,7 +5126,7 @@ fn test_bitlist_bitlist_8_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_4() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -5154,7 +5154,7 @@ fn test_bitlist_bitlist_512_max_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1bb7ab569c8b46d1e40884241195c1369ea760bf957583d3a78a4315c0e2f495");
     assert_eq!(root, expected_root);
@@ -5162,7 +5162,7 @@ fn test_bitlist_bitlist_512_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_4() {
-    let value = Bitlist::<5>::from_iter([true, true]);
+    let mut value = Bitlist::<5>::from_iter([true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_max_4/serialized.ssz_snappy",
@@ -5172,7 +5172,7 @@ fn test_bitlist_bitlist_5_max_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -5180,7 +5180,7 @@ fn test_bitlist_bitlist_5_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_3() {
-    let value = Bitlist::<5>::from_iter([true, true, true, true]);
+    let mut value = Bitlist::<5>::from_iter([true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_max_3/serialized.ssz_snappy",
@@ -5190,7 +5190,7 @@ fn test_bitlist_bitlist_5_max_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4b07c3799db025f3aa92ced1e8545367a2b6e44960f479d3f9d62b61812892d5");
     assert_eq!(root, expected_root);
@@ -5198,7 +5198,7 @@ fn test_bitlist_bitlist_5_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_0() {
-    let value = Bitlist::<16>::from_iter([]);
+    let mut value = Bitlist::<16>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_16_nil_0/serialized.ssz_snappy",
@@ -5208,7 +5208,7 @@ fn test_bitlist_bitlist_16_nil_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5216,7 +5216,7 @@ fn test_bitlist_bitlist_16_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_4() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_nil_4/serialized.ssz_snappy",
@@ -5226,7 +5226,7 @@ fn test_bitlist_bitlist_1_nil_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5234,7 +5234,7 @@ fn test_bitlist_bitlist_1_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_3() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_nil_3/serialized.ssz_snappy",
@@ -5244,7 +5244,7 @@ fn test_bitlist_bitlist_1_nil_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5252,7 +5252,7 @@ fn test_bitlist_bitlist_1_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_4() {
-    let value = Bitlist::<8>::from_iter([true, true, false, false, false, true, true, true]);
+    let mut value = Bitlist::<8>::from_iter([true, true, false, false, false, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_lengthy_4/serialized.ssz_snappy",
@@ -5262,7 +5262,7 @@ fn test_bitlist_bitlist_8_lengthy_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6d1fd4c1b192e8aeb35074214855c593805c2ed1ff79f7aa7c6128814fa41bf3");
     assert_eq!(root, expected_root);
@@ -5270,7 +5270,7 @@ fn test_bitlist_bitlist_8_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_3() {
-    let value = Bitlist::<8>::from_iter([true, true, false, false, false, true, true, false]);
+    let mut value = Bitlist::<8>::from_iter([true, true, false, false, false, true, true, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_lengthy_3/serialized.ssz_snappy",
@@ -5280,7 +5280,7 @@ fn test_bitlist_bitlist_8_lengthy_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b8148b13b48faa79622d9a6975e7abdf85dd4639a25e53412eb0aa5c34386019");
     assert_eq!(root, expected_root);
@@ -5288,7 +5288,7 @@ fn test_bitlist_bitlist_8_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_2() {
-    let value = Bitlist::<512>::from_iter([
+    let mut value = Bitlist::<512>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -5319,7 +5319,7 @@ fn test_bitlist_bitlist_512_max_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("08e61443f630601ca65f47622a47ef029baad7a757f3f1d10de0098c9add4589");
     assert_eq!(root, expected_root);
@@ -5327,7 +5327,7 @@ fn test_bitlist_bitlist_512_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_1() {
-    let value = Bitlist::<8>::from_iter([]);
+    let mut value = Bitlist::<8>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_8_nil_1/serialized.ssz_snappy",
@@ -5337,7 +5337,7 @@ fn test_bitlist_bitlist_8_nil_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5345,7 +5345,7 @@ fn test_bitlist_bitlist_8_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_3() {
-    let value = Bitlist::<31>::from_iter([true, true, false, true, true, false, false, true]);
+    let mut value = Bitlist::<31>::from_iter([true, true, false, true, true, false, false, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_random_3/serialized.ssz_snappy",
@@ -5355,7 +5355,7 @@ fn test_bitlist_bitlist_31_random_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5940967aaa293730d0e7876047dfceb9cf5512fafb5d4be3d05c776902163786");
     assert_eq!(root, expected_root);
@@ -5363,7 +5363,7 @@ fn test_bitlist_bitlist_31_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_1() {
-    let value = Bitlist::<16>::from_iter([
+    let mut value = Bitlist::<16>::from_iter([
         false, false, false, false, false, false, false, false, false,
     ]);
     let encoding = serialize(&value);
@@ -5375,7 +5375,7 @@ fn test_bitlist_bitlist_16_zero_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7b460f51b362b95b384743dda74f56fbcd35f4d8e7ebda7206632e60c91e663d");
     assert_eq!(root, expected_root);
@@ -5383,7 +5383,7 @@ fn test_bitlist_bitlist_16_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_2() {
-    let value = Bitlist::<3>::from_iter([]);
+    let mut value = Bitlist::<3>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_3_nil_2/serialized.ssz_snappy",
@@ -5393,7 +5393,7 @@ fn test_bitlist_bitlist_3_nil_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5401,7 +5401,7 @@ fn test_bitlist_bitlist_3_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_0() {
-    let value = Bitlist::<4>::from_iter([true, false, true]);
+    let mut value = Bitlist::<4>::from_iter([true, false, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_4_random_0/serialized.ssz_snappy",
@@ -5411,7 +5411,7 @@ fn test_bitlist_bitlist_4_random_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cf8ca64c265b9b6234fb7573a200745204fd04fecf680f1157f27367ee8f4aa2");
     assert_eq!(root, expected_root);
@@ -5419,7 +5419,7 @@ fn test_bitlist_bitlist_4_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_3() {
-    let value = Bitlist::<1>::from_iter([]);
+    let mut value = Bitlist::<1>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_zero_3/serialized.ssz_snappy",
@@ -5429,7 +5429,7 @@ fn test_bitlist_bitlist_1_zero_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5437,7 +5437,7 @@ fn test_bitlist_bitlist_1_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_0() {
-    let value = Bitlist::<5>::from_iter([]);
+    let mut value = Bitlist::<5>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_random_0/serialized.ssz_snappy",
@@ -5447,7 +5447,7 @@ fn test_bitlist_bitlist_5_random_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5455,7 +5455,7 @@ fn test_bitlist_bitlist_5_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_2() {
-    let value = Bitlist::<5>::from_iter([false, true, false, false, false]);
+    let mut value = Bitlist::<5>::from_iter([false, true, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_5_lengthy_2/serialized.ssz_snappy",
@@ -5465,7 +5465,7 @@ fn test_bitlist_bitlist_5_lengthy_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d13061c7b549c86b29ad2389cbe4fb2fd05bbdf3170da634e67f77ab981b82cb");
     assert_eq!(root, expected_root);
@@ -5473,7 +5473,7 @@ fn test_bitlist_bitlist_5_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_4() {
-    let value = Bitlist::<31>::from_iter([]);
+    let mut value = Bitlist::<31>::from_iter([]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_31_random_4/serialized.ssz_snappy",
@@ -5483,7 +5483,7 @@ fn test_bitlist_bitlist_31_random_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -5491,7 +5491,7 @@ fn test_bitlist_bitlist_31_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_4() {
-    let value = Bitlist::<1>::from_iter([false]);
+    let mut value = Bitlist::<1>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitlist/valid/bitlist_1_zero_4/serialized.ssz_snappy",
@@ -5501,7 +5501,7 @@ fn test_bitlist_bitlist_1_zero_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);

--- a/ssz_rs/tests/bitvector.rs
+++ b/ssz_rs/tests/bitvector.rs
@@ -7,7 +7,7 @@ use test_utils::{
 
 #[test]
 fn test_bitvector_bitvec_5_max() {
-    let value = Bitvector::<5>::from_iter([true, true, true, true, true]);
+    let mut value = Bitvector::<5>::from_iter([true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_5_max/serialized.ssz_snappy",
@@ -17,7 +17,7 @@ fn test_bitvector_bitvec_5_max() {
     let recovered_value: Bitvector<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1f00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -25,7 +25,7 @@ fn test_bitvector_bitvec_5_max() {
 
 #[test]
 fn test_bitvector_bitvec_1_random() {
-    let value = Bitvector::<1>::from_iter([false]);
+    let mut value = Bitvector::<1>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_1_random/serialized.ssz_snappy",
@@ -35,7 +35,7 @@ fn test_bitvector_bitvec_1_random() {
     let recovered_value: Bitvector<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -43,7 +43,7 @@ fn test_bitvector_bitvec_1_random() {
 
 #[test]
 fn test_bitvector_bitvec_512_random() {
-    let value = Bitvector::<512>::from_iter([
+    let mut value = Bitvector::<512>::from_iter([
         false, false, false, false, true, false, true, false, false, false, false, true, true,
         false, false, true, true, false, false, false, true, false, true, true, false, true, false,
         false, true, true, false, true, true, false, true, true, true, false, false, false, true,
@@ -92,7 +92,7 @@ fn test_bitvector_bitvec_512_random() {
     let recovered_value: Bitvector<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fbdb71e991457c4fd956e16be1ae1dc959bceaf00f692fec9431de3f0175655a");
     assert_eq!(root, expected_root);
@@ -100,7 +100,7 @@ fn test_bitvector_bitvec_512_random() {
 
 #[test]
 fn test_bitvector_bitvec_4_max() {
-    let value = Bitvector::<4>::from_iter([true, true, true, true]);
+    let mut value = Bitvector::<4>::from_iter([true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_4_max/serialized.ssz_snappy",
@@ -110,7 +110,7 @@ fn test_bitvector_bitvec_4_max() {
     let recovered_value: Bitvector<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0f00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -118,7 +118,7 @@ fn test_bitvector_bitvec_4_max() {
 
 #[test]
 fn test_bitvector_bitvec_5_zero() {
-    let value = Bitvector::<5>::from_iter([false, false, false, false, false]);
+    let mut value = Bitvector::<5>::from_iter([false, false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_5_zero/serialized.ssz_snappy",
@@ -128,7 +128,7 @@ fn test_bitvector_bitvec_5_zero() {
     let recovered_value: Bitvector<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -136,7 +136,7 @@ fn test_bitvector_bitvec_5_zero() {
 
 #[test]
 fn test_bitvector_bitvec_3_max() {
-    let value = Bitvector::<3>::from_iter([true, true, true]);
+    let mut value = Bitvector::<3>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_3_max/serialized.ssz_snappy",
@@ -146,7 +146,7 @@ fn test_bitvector_bitvec_3_max() {
     let recovered_value: Bitvector<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0700000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -154,7 +154,7 @@ fn test_bitvector_bitvec_3_max() {
 
 #[test]
 fn test_bitvector_bitvec_4_zero() {
-    let value = Bitvector::<4>::from_iter([false, false, false, false]);
+    let mut value = Bitvector::<4>::from_iter([false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_4_zero/serialized.ssz_snappy",
@@ -164,7 +164,7 @@ fn test_bitvector_bitvec_4_zero() {
     let recovered_value: Bitvector<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -172,7 +172,7 @@ fn test_bitvector_bitvec_4_zero() {
 
 #[test]
 fn test_bitvector_bitvec_31_zero() {
-    let value = Bitvector::<31>::from_iter([
+    let mut value = Bitvector::<31>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false,
@@ -186,7 +186,7 @@ fn test_bitvector_bitvec_31_zero() {
     let recovered_value: Bitvector<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -194,7 +194,7 @@ fn test_bitvector_bitvec_31_zero() {
 
 #[test]
 fn test_bitvector_bitvec_2_max() {
-    let value = Bitvector::<2>::from_iter([true, true]);
+    let mut value = Bitvector::<2>::from_iter([true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_2_max/serialized.ssz_snappy",
@@ -204,7 +204,7 @@ fn test_bitvector_bitvec_2_max() {
     let recovered_value: Bitvector<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -212,7 +212,7 @@ fn test_bitvector_bitvec_2_max() {
 
 #[test]
 fn test_bitvector_bitvec_3_random() {
-    let value = Bitvector::<3>::from_iter([true, true, true]);
+    let mut value = Bitvector::<3>::from_iter([true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_3_random/serialized.ssz_snappy",
@@ -222,7 +222,7 @@ fn test_bitvector_bitvec_3_random() {
     let recovered_value: Bitvector<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0700000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -230,7 +230,8 @@ fn test_bitvector_bitvec_3_random() {
 
 #[test]
 fn test_bitvector_bitvec_8_zero() {
-    let value = Bitvector::<8>::from_iter([false, false, false, false, false, false, false, false]);
+    let mut value =
+        Bitvector::<8>::from_iter([false, false, false, false, false, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_8_zero/serialized.ssz_snappy",
@@ -240,7 +241,7 @@ fn test_bitvector_bitvec_8_zero() {
     let recovered_value: Bitvector<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -248,7 +249,7 @@ fn test_bitvector_bitvec_8_zero() {
 
 #[test]
 fn test_bitvector_bitvec_31_max() {
-    let value = Bitvector::<31>::from_iter([
+    let mut value = Bitvector::<31>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true,
@@ -262,7 +263,7 @@ fn test_bitvector_bitvec_31_max() {
     let recovered_value: Bitvector<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffff7f00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -270,7 +271,7 @@ fn test_bitvector_bitvec_31_max() {
 
 #[test]
 fn test_bitvector_bitvec_16_random() {
-    let value = Bitvector::<16>::from_iter([
+    let mut value = Bitvector::<16>::from_iter([
         false, true, true, true, false, true, false, false, false, false, true, true, false, true,
         true, true,
     ]);
@@ -283,7 +284,7 @@ fn test_bitvector_bitvec_16_random() {
     let recovered_value: Bitvector<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2eec000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -291,7 +292,7 @@ fn test_bitvector_bitvec_16_random() {
 
 #[test]
 fn test_bitvector_bitvec_1_max() {
-    let value = Bitvector::<1>::from_iter([true]);
+    let mut value = Bitvector::<1>::from_iter([true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_1_max/serialized.ssz_snappy",
@@ -301,7 +302,7 @@ fn test_bitvector_bitvec_1_max() {
     let recovered_value: Bitvector<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -309,7 +310,7 @@ fn test_bitvector_bitvec_1_max() {
 
 #[test]
 fn test_bitvector_bitvec_3_zero() {
-    let value = Bitvector::<3>::from_iter([false, false, false]);
+    let mut value = Bitvector::<3>::from_iter([false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_3_zero/serialized.ssz_snappy",
@@ -319,7 +320,7 @@ fn test_bitvector_bitvec_3_zero() {
     let recovered_value: Bitvector<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -327,7 +328,7 @@ fn test_bitvector_bitvec_3_zero() {
 
 #[test]
 fn test_bitvector_bitvec_16_zero() {
-    let value = Bitvector::<16>::from_iter([
+    let mut value = Bitvector::<16>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false,
     ]);
@@ -340,7 +341,7 @@ fn test_bitvector_bitvec_16_zero() {
     let recovered_value: Bitvector<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -348,7 +349,7 @@ fn test_bitvector_bitvec_16_zero() {
 
 #[test]
 fn test_bitvector_bitvec_512_max() {
-    let value = Bitvector::<512>::from_iter([
+    let mut value = Bitvector::<512>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -394,7 +395,7 @@ fn test_bitvector_bitvec_512_max() {
     let recovered_value: Bitvector<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -402,7 +403,7 @@ fn test_bitvector_bitvec_512_max() {
 
 #[test]
 fn test_bitvector_bitvec_5_random() {
-    let value = Bitvector::<5>::from_iter([true, true, false, false, false]);
+    let mut value = Bitvector::<5>::from_iter([true, true, false, false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_5_random/serialized.ssz_snappy",
@@ -412,7 +413,7 @@ fn test_bitvector_bitvec_5_random() {
     let recovered_value: Bitvector<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -420,7 +421,7 @@ fn test_bitvector_bitvec_5_random() {
 
 #[test]
 fn test_bitvector_bitvec_513_max() {
-    let value = Bitvector::<513>::from_iter([
+    let mut value = Bitvector::<513>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -466,7 +467,7 @@ fn test_bitvector_bitvec_513_max() {
     let recovered_value: Bitvector<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("222dd9eebc6467de9788eb1c05ce9c2da8ecc89abdd38810925ce061d91236ef");
     assert_eq!(root, expected_root);
@@ -474,7 +475,7 @@ fn test_bitvector_bitvec_513_max() {
 
 #[test]
 fn test_bitvector_bitvec_2_zero() {
-    let value = Bitvector::<2>::from_iter([false, false]);
+    let mut value = Bitvector::<2>::from_iter([false, false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_2_zero/serialized.ssz_snappy",
@@ -484,7 +485,7 @@ fn test_bitvector_bitvec_2_zero() {
     let recovered_value: Bitvector<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -492,7 +493,7 @@ fn test_bitvector_bitvec_2_zero() {
 
 #[test]
 fn test_bitvector_bitvec_1_zero() {
-    let value = Bitvector::<1>::from_iter([false]);
+    let mut value = Bitvector::<1>::from_iter([false]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_1_zero/serialized.ssz_snappy",
@@ -502,7 +503,7 @@ fn test_bitvector_bitvec_1_zero() {
     let recovered_value: Bitvector<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -510,7 +511,7 @@ fn test_bitvector_bitvec_1_zero() {
 
 #[test]
 fn test_bitvector_bitvec_512_zero() {
-    let value = Bitvector::<512>::from_iter([
+    let mut value = Bitvector::<512>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -561,7 +562,7 @@ fn test_bitvector_bitvec_512_zero() {
     let recovered_value: Bitvector<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -569,7 +570,7 @@ fn test_bitvector_bitvec_512_zero() {
 
 #[test]
 fn test_bitvector_bitvec_513_random() {
-    let value = Bitvector::<513>::from_iter([
+    let mut value = Bitvector::<513>::from_iter([
         true, true, false, false, false, true, false, false, true, true, true, false, false, false,
         false, false, true, true, true, true, false, false, true, true, true, false, true, true,
         false, false, true, false, false, true, false, false, true, true, true, false, true, false,
@@ -618,7 +619,7 @@ fn test_bitvector_bitvec_513_random() {
     let recovered_value: Bitvector<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("84f06e5024cc71b8162c3a96f4b743505481722da5a281a6aaa69791b9f79283");
     assert_eq!(root, expected_root);
@@ -626,7 +627,7 @@ fn test_bitvector_bitvec_513_random() {
 
 #[test]
 fn test_bitvector_bitvec_31_random() {
-    let value = Bitvector::<31>::from_iter([
+    let mut value = Bitvector::<31>::from_iter([
         false, true, false, false, true, true, true, false, true, true, true, true, true, false,
         true, true, false, false, true, false, false, true, true, false, true, false, true, false,
         true, false, false,
@@ -640,7 +641,7 @@ fn test_bitvector_bitvec_31_random() {
     let recovered_value: Bitvector<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("72df641500000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -648,7 +649,7 @@ fn test_bitvector_bitvec_31_random() {
 
 #[test]
 fn test_bitvector_bitvec_2_random() {
-    let value = Bitvector::<2>::from_iter([true, true]);
+    let mut value = Bitvector::<2>::from_iter([true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_2_random/serialized.ssz_snappy",
@@ -658,7 +659,7 @@ fn test_bitvector_bitvec_2_random() {
     let recovered_value: Bitvector<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -666,7 +667,7 @@ fn test_bitvector_bitvec_2_random() {
 
 #[test]
 fn test_bitvector_bitvec_513_zero() {
-    let value = Bitvector::<513>::from_iter([
+    let mut value = Bitvector::<513>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -717,7 +718,7 @@ fn test_bitvector_bitvec_513_zero() {
     let recovered_value: Bitvector<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -725,7 +726,7 @@ fn test_bitvector_bitvec_513_zero() {
 
 #[test]
 fn test_bitvector_bitvec_16_max() {
-    let value = Bitvector::<16>::from_iter([
+    let mut value = Bitvector::<16>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true,
     ]);
@@ -738,7 +739,7 @@ fn test_bitvector_bitvec_16_max() {
     let recovered_value: Bitvector<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -746,7 +747,7 @@ fn test_bitvector_bitvec_16_max() {
 
 #[test]
 fn test_bitvector_bitvec_4_random() {
-    let value = Bitvector::<4>::from_iter([true, false, true, true]);
+    let mut value = Bitvector::<4>::from_iter([true, false, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_4_random/serialized.ssz_snappy",
@@ -756,7 +757,7 @@ fn test_bitvector_bitvec_4_random() {
     let recovered_value: Bitvector<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0d00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -764,7 +765,7 @@ fn test_bitvector_bitvec_4_random() {
 
 #[test]
 fn test_bitvector_bitvec_8_random() {
-    let value = Bitvector::<8>::from_iter([true, true, true, true, true, false, true, true]);
+    let mut value = Bitvector::<8>::from_iter([true, true, true, true, true, false, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_8_random/serialized.ssz_snappy",
@@ -774,7 +775,7 @@ fn test_bitvector_bitvec_8_random() {
     let recovered_value: Bitvector<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("df00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -782,7 +783,7 @@ fn test_bitvector_bitvec_8_random() {
 
 #[test]
 fn test_bitvector_bitvec_8_max() {
-    let value = Bitvector::<8>::from_iter([true, true, true, true, true, true, true, true]);
+    let mut value = Bitvector::<8>::from_iter([true, true, true, true, true, true, true, true]);
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/bitvector/valid/bitvec_8_max/serialized.ssz_snappy",
@@ -792,7 +793,7 @@ fn test_bitvector_bitvec_8_max() {
     let recovered_value: Bitvector<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);

--- a/ssz_rs/tests/boolean.rs
+++ b/ssz_rs/tests/boolean.rs
@@ -7,7 +7,7 @@ use test_utils::{
 
 #[test]
 fn test_boolean_true() {
-    let value = true;
+    let mut value = true;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/boolean/valid/true/serialized.ssz_snappy",
@@ -17,7 +17,7 @@ fn test_boolean_true() {
     let recovered_value: bool = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -25,7 +25,7 @@ fn test_boolean_true() {
 
 #[test]
 fn test_boolean_false() {
-    let value = false;
+    let mut value = false;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/boolean/valid/false/serialized.ssz_snappy",
@@ -35,7 +35,7 @@ fn test_boolean_false() {
     let recovered_value: bool = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);

--- a/ssz_rs/tests/containers.rs
+++ b/ssz_rs/tests/containers.rs
@@ -52,7 +52,7 @@ struct BitsStruct {
 
 #[test]
 fn test_containers_var_test_struct_zero_chaos_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -99,7 +99,7 @@ fn test_containers_var_test_struct_zero_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e0021bb04ff4cbf7fdb8ce02d79ed8295dedafb6f1b44a30a500cc97d800e36a");
     assert_eq!(root, expected_root);
@@ -107,7 +107,7 @@ fn test_containers_var_test_struct_zero_chaos_2() {
 
 #[test]
 fn test_containers_bits_struct_random_chaos_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true, false, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -123,7 +123,7 @@ fn test_containers_bits_struct_random_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f11a74232c75623074eeb6bf827b692e43f613e672b40ed442f72cd01c5ee2f4");
     assert_eq!(root, expected_root);
@@ -131,7 +131,7 @@ fn test_containers_bits_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_max_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535]),
         c: 255,
@@ -303,7 +303,7 @@ fn test_containers_complex_test_struct_max_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9a7021a723498d5ae6cadbc025f7ff755e98438d410ce09fd55b27a9e6a25a5c");
     assert_eq!(root, expected_root);
@@ -311,7 +311,7 @@ fn test_containers_complex_test_struct_max_0() {
 
 #[test]
 fn test_containers_complex_test_struct_max_7() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -491,7 +491,7 @@ fn test_containers_complex_test_struct_max_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2355b8f62ff0427f4f1bda41968c93eb41f6be15f2989b2e235ab24772699bbf");
     assert_eq!(root, expected_root);
@@ -499,7 +499,7 @@ fn test_containers_complex_test_struct_max_7() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_chaos_2() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_chaos_2/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -507,7 +507,7 @@ fn test_containers_single_field_test_struct_max_chaos_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -515,7 +515,7 @@ fn test_containers_single_field_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_chaos_1() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_chaos_1/serialized.ssz_snappy",
@@ -525,7 +525,7 @@ fn test_containers_fixed_test_struct_zero_chaos_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -533,7 +533,7 @@ fn test_containers_fixed_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_one_3() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 49003,
         b: List::<u16, 128>::from_iter([15653]),
         c: 239,
@@ -587,7 +587,7 @@ fn test_containers_complex_test_struct_one_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1adf1503de419e5735c87cd21784ddf520cb547be4f18ea5d25390d65a654ef1");
     assert_eq!(root, expected_root);
@@ -595,7 +595,7 @@ fn test_containers_complex_test_struct_one_3() {
 
 #[test]
 fn test_containers_complex_test_struct_one_4() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 33449,
         b: List::<u16, 128>::from_iter([11465]),
         c: 54,
@@ -649,7 +649,7 @@ fn test_containers_complex_test_struct_one_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f8591818dc82c94e16373493167e3a04d837fe453a532336d2f4b80c986b7da5");
     assert_eq!(root, expected_root);
@@ -657,7 +657,7 @@ fn test_containers_complex_test_struct_one_4() {
 
 #[test]
 fn test_containers_complex_test_struct_max_9() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -967,7 +967,7 @@ fn test_containers_complex_test_struct_max_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8fc6ab2617bc9d8e8b0156ec1c6cda0d5b9f09c91e2ab52900e65376c767bfc3");
     assert_eq!(root, expected_root);
@@ -975,7 +975,7 @@ fn test_containers_complex_test_struct_max_9() {
 
 #[test]
 fn test_containers_small_test_struct_zero() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero/serialized.ssz_snappy",
@@ -985,7 +985,7 @@ fn test_containers_small_test_struct_zero() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -993,7 +993,7 @@ fn test_containers_small_test_struct_zero() {
 
 #[test]
 fn test_containers_bits_struct_zero_chaos_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -1009,7 +1009,7 @@ fn test_containers_bits_struct_zero_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("aaaa3533b5c1fb113f5629286d167a1c134872b245c59f5b1f547fc325618d84");
     assert_eq!(root, expected_root);
@@ -1017,7 +1017,7 @@ fn test_containers_bits_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_8() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_8/serialized.ssz_snappy",
@@ -1027,7 +1027,7 @@ fn test_containers_single_field_test_struct_max_8() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1035,7 +1035,7 @@ fn test_containers_single_field_test_struct_max_8() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_1() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_1/serialized.ssz_snappy",
@@ -1045,7 +1045,7 @@ fn test_containers_single_field_test_struct_max_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1053,7 +1053,7 @@ fn test_containers_single_field_test_struct_max_1() {
 
 #[test]
 fn test_containers_bits_struct_random_5() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, true]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -1069,7 +1069,7 @@ fn test_containers_bits_struct_random_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5c652a6881fdbcf2bb433889972d124eeaefc56e933603449bd5654f3aa77f4d");
     assert_eq!(root, expected_root);
@@ -1077,7 +1077,7 @@ fn test_containers_bits_struct_random_5() {
 
 #[test]
 fn test_containers_bits_struct_max_chaos_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -1093,7 +1093,7 @@ fn test_containers_bits_struct_max_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f4d67e998921885ee4480b12b72a3fa729ac54f8b6c5b7e02bfc5be185bcec3a");
     assert_eq!(root, expected_root);
@@ -1101,7 +1101,7 @@ fn test_containers_bits_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1211,7 +1211,7 @@ fn test_containers_complex_test_struct_zero_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1f6d75d4252f3c39169e59d7831661be5224e98bd91460fd93582645af0e8abf");
     assert_eq!(root, expected_root);
@@ -1219,7 +1219,7 @@ fn test_containers_complex_test_struct_zero_2() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_3() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_3/serialized.ssz_snappy",
@@ -1229,7 +1229,7 @@ fn test_containers_single_field_test_struct_zero_3() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1237,7 +1237,7 @@ fn test_containers_single_field_test_struct_zero_3() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_6() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_6/serialized.ssz_snappy",
@@ -1247,7 +1247,7 @@ fn test_containers_single_field_test_struct_max_6() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1255,7 +1255,7 @@ fn test_containers_single_field_test_struct_max_6() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_4() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_4/serialized.ssz_snappy",
@@ -1265,7 +1265,7 @@ fn test_containers_single_field_test_struct_zero_4() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1273,7 +1273,7 @@ fn test_containers_single_field_test_struct_zero_4() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_5() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1348,7 +1348,7 @@ fn test_containers_complex_test_struct_zero_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b14eff3c8dcf43636fb3674437f01c1e31541a4fe2f59fce85969931cf502e66");
     assert_eq!(root, expected_root);
@@ -1356,7 +1356,7 @@ fn test_containers_complex_test_struct_zero_5() {
 
 #[test]
 fn test_containers_bits_struct_random_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -1372,7 +1372,7 @@ fn test_containers_bits_struct_random_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b8f13ccf822810bb645e3c6fb81ebb92971e06d9a3bffb4ec521f55de27f8138");
     assert_eq!(root, expected_root);
@@ -1380,7 +1380,7 @@ fn test_containers_bits_struct_random_2() {
 
 #[test]
 fn test_containers_complex_test_struct_one_5() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 522,
         b: List::<u16, 128>::from_iter([58016]),
         c: 1,
@@ -1434,7 +1434,7 @@ fn test_containers_complex_test_struct_one_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("65b2e7eb07c99979ba85bc12bfb32c3f443bdc9a0a5ea5c284d5f4a4a8255615");
     assert_eq!(root, expected_root);
@@ -1442,7 +1442,7 @@ fn test_containers_complex_test_struct_one_5() {
 
 #[test]
 fn test_containers_complex_test_struct_max_8() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -1637,7 +1637,7 @@ fn test_containers_complex_test_struct_max_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("92ca028b53e0f56f97935a2a736f42f176f4810165ed93b8aae9637825ceecf6");
     assert_eq!(root, expected_root);
@@ -1645,7 +1645,7 @@ fn test_containers_complex_test_struct_max_8() {
 
 #[test]
 fn test_containers_complex_test_struct_one_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 12541,
         b: List::<u16, 128>::from_iter([2249]),
         c: 53,
@@ -1699,7 +1699,7 @@ fn test_containers_complex_test_struct_one_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("bfb6c2ce9bbc2339a06b32d54b9beebb6628397f1bc9f31b2919045350e076da");
     assert_eq!(root, expected_root);
@@ -1707,7 +1707,7 @@ fn test_containers_complex_test_struct_one_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_chaos_0() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_chaos_0/serialized.ssz_snappy",
@@ -1717,7 +1717,7 @@ fn test_containers_fixed_test_struct_zero_chaos_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -1725,7 +1725,7 @@ fn test_containers_fixed_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_max_6() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -1950,7 +1950,7 @@ fn test_containers_complex_test_struct_max_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f2e200a0ed6dddf52d635ab3b163ab612c1e8f1d9f614f3aef85beb4cd66cdd2");
     assert_eq!(root, expected_root);
@@ -1958,7 +1958,7 @@ fn test_containers_complex_test_struct_max_6() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_chaos_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 43914,
         b: List::<u16, 128>::from_iter([
             62086, 1328, 36452, 57324, 9737, 54653, 31513, 53012, 55142, 1461, 52584, 61080, 47577,
@@ -2312,7 +2312,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b4e8f7ebdf3579a50da0cbf6eb889fafa7daef0efffb0fc165d76d88dff40bf4");
     assert_eq!(root, expected_root);
@@ -2320,7 +2320,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_2() {
 
 #[test]
 fn test_containers_complex_test_struct_max_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -2508,7 +2508,7 @@ fn test_containers_complex_test_struct_max_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("822b36c8a4513b7c9c81f8100a99b1ca977fc64a180154af81c27af6ce6da5a8");
     assert_eq!(root, expected_root);
@@ -2516,7 +2516,7 @@ fn test_containers_complex_test_struct_max_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero/serialized.ssz_snappy",
@@ -2526,7 +2526,7 @@ fn test_containers_fixed_test_struct_zero() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -2534,7 +2534,7 @@ fn test_containers_fixed_test_struct_zero() {
 
 #[test]
 fn test_containers_bits_struct_random_chaos_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -2550,7 +2550,7 @@ fn test_containers_bits_struct_random_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("38c9859e2c0584a1802aa9b25ec33db9dae9df50169d68d948b589d8eb01f7aa");
     assert_eq!(root, expected_root);
@@ -2558,7 +2558,7 @@ fn test_containers_bits_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_7() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_7/serialized.ssz_snappy",
@@ -2568,7 +2568,7 @@ fn test_containers_single_field_test_struct_max_7() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2576,7 +2576,7 @@ fn test_containers_single_field_test_struct_max_7() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_4() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2684,7 +2684,7 @@ fn test_containers_complex_test_struct_zero_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8021f013769eba11681a8dcf7458660e19c30efe1b95bf0ad1d047a80a51bcc5");
     assert_eq!(root, expected_root);
@@ -2692,7 +2692,7 @@ fn test_containers_complex_test_struct_zero_4() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_5() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_5/serialized.ssz_snappy",
@@ -2702,7 +2702,7 @@ fn test_containers_single_field_test_struct_zero_5() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2710,7 +2710,7 @@ fn test_containers_single_field_test_struct_zero_5() {
 
 #[test]
 fn test_containers_bits_struct_random_3() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, false, true]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -2726,7 +2726,7 @@ fn test_containers_bits_struct_random_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("00bebd4ee633b4af3e0247fbba72ff80727cd84e5999374dabf8ba04740114aa");
     assert_eq!(root, expected_root);
@@ -2734,7 +2734,7 @@ fn test_containers_bits_struct_random_3() {
 
 #[test]
 fn test_containers_complex_test_struct_one_chaos_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 30483,
         b: List::<u16, 128>::from_iter([9712]),
         c: 0,
@@ -2788,7 +2788,7 @@ fn test_containers_complex_test_struct_one_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("887aeaa4092a72ed26e711b4e2147f1c1ee3de66f61641981c17326727824d53");
     assert_eq!(root, expected_root);
@@ -2796,7 +2796,7 @@ fn test_containers_complex_test_struct_one_chaos_2() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_0() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_0/serialized.ssz_snappy",
@@ -2806,7 +2806,7 @@ fn test_containers_single_field_test_struct_max_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2814,7 +2814,7 @@ fn test_containers_single_field_test_struct_max_0() {
 
 #[test]
 fn test_containers_bits_struct_random_4() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, true]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -2830,7 +2830,7 @@ fn test_containers_bits_struct_random_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a72542f6f22787da3a00dc428c75c8dd6a75dab48cc8fb663f65594e7947e63a");
     assert_eq!(root, expected_root);
@@ -2838,7 +2838,7 @@ fn test_containers_bits_struct_random_4() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_2() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_2/serialized.ssz_snappy",
@@ -2848,7 +2848,7 @@ fn test_containers_single_field_test_struct_zero_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -2856,7 +2856,7 @@ fn test_containers_single_field_test_struct_zero_2() {
 
 #[test]
 fn test_containers_bits_struct_max_chaos_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -2872,7 +2872,7 @@ fn test_containers_bits_struct_max_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d14588c56f40c8ec3eae3b9a658aab2baac9cc08c418d609737dc6137b90045b");
     assert_eq!(root, expected_root);
@@ -2880,7 +2880,7 @@ fn test_containers_bits_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_3() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2983,7 +2983,7 @@ fn test_containers_complex_test_struct_zero_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("10d835c8af095afc274d2a76ce98ebeb857396a8f68cbf524d14d3521076c3f8");
     assert_eq!(root, expected_root);
@@ -2991,7 +2991,7 @@ fn test_containers_complex_test_struct_zero_3() {
 
 #[test]
 fn test_containers_bits_struct_zero_chaos_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -3007,7 +3007,7 @@ fn test_containers_bits_struct_zero_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("27b61f43e35013d439d4d131de8ad79811792cf58724d87ae45f1f3d1f74bacd");
     assert_eq!(root, expected_root);
@@ -3015,7 +3015,7 @@ fn test_containers_bits_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_9() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_9/serialized.ssz_snappy",
@@ -3025,7 +3025,7 @@ fn test_containers_single_field_test_struct_max_9() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3033,7 +3033,7 @@ fn test_containers_single_field_test_struct_max_9() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_6() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -3047,7 +3047,7 @@ fn test_containers_fixed_test_struct_max_6() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -3055,7 +3055,7 @@ fn test_containers_fixed_test_struct_max_6() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_1() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -3069,7 +3069,7 @@ fn test_containers_fixed_test_struct_max_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -3077,7 +3077,7 @@ fn test_containers_fixed_test_struct_max_1() {
 
 #[test]
 fn test_containers_small_test_struct_zero_chaos_2() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_chaos_2/serialized.ssz_snappy",
@@ -3087,7 +3087,7 @@ fn test_containers_small_test_struct_zero_chaos_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3095,7 +3095,7 @@ fn test_containers_small_test_struct_zero_chaos_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_8() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -3109,7 +3109,7 @@ fn test_containers_fixed_test_struct_max_8() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -3117,7 +3117,7 @@ fn test_containers_fixed_test_struct_max_8() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 52446,
         b: List::<u16, 128>::from_iter([]),
         c: 216,
@@ -3171,7 +3171,7 @@ fn test_containers_complex_test_struct_nil_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3ad080351afcde8c45956a9dbba68db5b7bd737f5be21f6b07833356b3b77ac5");
     assert_eq!(root, expected_root);
@@ -3179,7 +3179,7 @@ fn test_containers_complex_test_struct_nil_1() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_chaos_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 43567,
         b: List::<u16, 128>::from_iter([]),
         c: 74,
@@ -3233,7 +3233,7 @@ fn test_containers_complex_test_struct_nil_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("643a44a63abc2b0c12c5db0dd5376fe5a6681e1336d0c0bf99a945d4aa9774e7");
     assert_eq!(root, expected_root);
@@ -3241,7 +3241,7 @@ fn test_containers_complex_test_struct_nil_chaos_2() {
 
 #[test]
 fn test_containers_small_test_struct_zero_9() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_9/serialized.ssz_snappy",
@@ -3251,7 +3251,7 @@ fn test_containers_small_test_struct_zero_9() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3259,7 +3259,7 @@ fn test_containers_small_test_struct_zero_9() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_6() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 14779,
         b: List::<u16, 128>::from_iter([]),
         c: 128,
@@ -3313,7 +3313,7 @@ fn test_containers_complex_test_struct_nil_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff282ed32a48f3c3cab8f5e90c41f31e3b765f98d841adf99f26b0afb1599c66");
     assert_eq!(root, expected_root);
@@ -3321,7 +3321,7 @@ fn test_containers_complex_test_struct_nil_6() {
 
 #[test]
 fn test_containers_small_test_struct_zero_0() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_0/serialized.ssz_snappy",
@@ -3331,7 +3331,7 @@ fn test_containers_small_test_struct_zero_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3339,7 +3339,7 @@ fn test_containers_small_test_struct_zero_0() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_8() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 9736,
         b: List::<u16, 128>::from_iter([]),
         c: 129,
@@ -3393,7 +3393,7 @@ fn test_containers_complex_test_struct_nil_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6660bf5b0be775c00b5a3a0bbeb90d8f110adb2bd54e7a1779a1230398b27f69");
     assert_eq!(root, expected_root);
@@ -3401,7 +3401,7 @@ fn test_containers_complex_test_struct_nil_8() {
 
 #[test]
 fn test_containers_small_test_struct_zero_7() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_7/serialized.ssz_snappy",
@@ -3411,7 +3411,7 @@ fn test_containers_small_test_struct_zero_7() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3419,7 +3419,7 @@ fn test_containers_small_test_struct_zero_7() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_chaos_2() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 30,
         b: 6156748712181862619,
         c: 562352362,
@@ -3433,7 +3433,7 @@ fn test_containers_fixed_test_struct_random_chaos_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5fddaefef3945fe9d1efe6d5f33d593db1cac4dc5e0edff46092b80ae564f713");
     assert_eq!(root, expected_root);
@@ -3441,7 +3441,7 @@ fn test_containers_fixed_test_struct_random_chaos_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_9() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -3455,7 +3455,7 @@ fn test_containers_fixed_test_struct_max_9() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -3463,7 +3463,7 @@ fn test_containers_fixed_test_struct_max_9() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_0() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -3477,7 +3477,7 @@ fn test_containers_fixed_test_struct_max_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -3485,7 +3485,7 @@ fn test_containers_fixed_test_struct_max_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_7() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -3499,7 +3499,7 @@ fn test_containers_fixed_test_struct_max_7() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -3507,7 +3507,7 @@ fn test_containers_fixed_test_struct_max_7() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_chaos_2() {
-    let value = SingleFieldTestStruct { a: 177 };
+    let mut value = SingleFieldTestStruct { a: 177 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_chaos_2/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -3515,7 +3515,7 @@ fn test_containers_single_field_test_struct_random_chaos_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -3523,7 +3523,7 @@ fn test_containers_single_field_test_struct_random_chaos_2() {
 
 #[test]
 fn test_containers_bits_struct_max() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -3539,7 +3539,7 @@ fn test_containers_bits_struct_max() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("696fb0974bbb2eb3a5d4a7613f2c3cabf81d28a8e51005e7fcab962da7ebca2b");
     assert_eq!(root, expected_root);
@@ -3547,7 +3547,7 @@ fn test_containers_bits_struct_max() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_9() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 23577,
         b: List::<u16, 128>::from_iter([]),
         c: 175,
@@ -3601,7 +3601,7 @@ fn test_containers_complex_test_struct_nil_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cc17028327728aac7c2760530199432a97ee4812bdd76faefb4b11bac84e981a");
     assert_eq!(root, expected_root);
@@ -3609,7 +3609,7 @@ fn test_containers_complex_test_struct_nil_9() {
 
 #[test]
 fn test_containers_small_test_struct_zero_6() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_6/serialized.ssz_snappy",
@@ -3619,7 +3619,7 @@ fn test_containers_small_test_struct_zero_6() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3627,7 +3627,7 @@ fn test_containers_small_test_struct_zero_6() {
 
 #[test]
 fn test_containers_small_test_struct_zero_1() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_1/serialized.ssz_snappy",
@@ -3637,7 +3637,7 @@ fn test_containers_small_test_struct_zero_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3645,7 +3645,7 @@ fn test_containers_small_test_struct_zero_1() {
 
 #[test]
 fn test_containers_var_test_struct_max_chaos_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -3677,7 +3677,7 @@ fn test_containers_var_test_struct_max_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e9aabd6fc8bc59fcbe5d369d36a5a7f4e4da30372c2ee0a79042c68b64306e2c");
     assert_eq!(root, expected_root);
@@ -3685,7 +3685,7 @@ fn test_containers_var_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_small_test_struct_zero_8() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_8/serialized.ssz_snappy",
@@ -3695,7 +3695,7 @@ fn test_containers_small_test_struct_zero_8() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -3703,7 +3703,7 @@ fn test_containers_small_test_struct_zero_8() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_7() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 50885,
         b: List::<u16, 128>::from_iter([]),
         c: 128,
@@ -3757,7 +3757,7 @@ fn test_containers_complex_test_struct_nil_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("354ebad67ef3b789f06d89b0ecea632024ca91d353f1e847e83111060f9b6523");
     assert_eq!(root, expected_root);
@@ -3765,7 +3765,7 @@ fn test_containers_complex_test_struct_nil_7() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 18142,
         b: List::<u16, 128>::from_iter([]),
         c: 231,
@@ -3819,7 +3819,7 @@ fn test_containers_complex_test_struct_nil_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("27375ceba8646507e7195acd6a9b584af05e32ac9939ef29df75faa8e1fb7198");
     assert_eq!(root, expected_root);
@@ -3827,7 +3827,7 @@ fn test_containers_complex_test_struct_nil_0() {
 
 #[test]
 fn test_containers_small_test_struct_max_0() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_0/serialized.ssz_snappy",
@@ -3837,7 +3837,7 @@ fn test_containers_small_test_struct_max_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -3845,7 +3845,7 @@ fn test_containers_small_test_struct_max_0() {
 
 #[test]
 fn test_containers_var_test_struct_zero_5() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3868,7 +3868,7 @@ fn test_containers_var_test_struct_zero_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4929401717bbb72c80a54a7d31d9fe75e36091585a2c188fa9f4a278cd28f504");
     assert_eq!(root, expected_root);
@@ -3876,7 +3876,7 @@ fn test_containers_var_test_struct_zero_5() {
 
 #[test]
 fn test_containers_bits_struct_zero_5() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -3892,7 +3892,7 @@ fn test_containers_bits_struct_zero_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a0ed0ec4a187f5f5a40bee9c8680cf42cf0a4c7631957639772eff3628d913f3");
     assert_eq!(root, expected_root);
@@ -3900,7 +3900,7 @@ fn test_containers_bits_struct_zero_5() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_9() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, false, true, false, true]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -3916,7 +3916,7 @@ fn test_containers_bits_struct_lengthy_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0ab92b5d899d3e4c819f32bda870df0d777c2eed0a22eee40532a3feff7eb197");
     assert_eq!(root, expected_root);
@@ -3924,7 +3924,7 @@ fn test_containers_bits_struct_lengthy_9() {
 
 #[test]
 fn test_containers_var_test_struct_zero_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([0, 0, 0]),
         c: 0,
@@ -3938,7 +3938,7 @@ fn test_containers_var_test_struct_zero_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("24635e0d491ca51baf0883d3e8b61f7684db971a9608fd4fb5b51a97257f976d");
     assert_eq!(root, expected_root);
@@ -3946,7 +3946,7 @@ fn test_containers_var_test_struct_zero_2() {
 
 #[test]
 fn test_containers_small_test_struct_max_7() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_7/serialized.ssz_snappy",
@@ -3956,7 +3956,7 @@ fn test_containers_small_test_struct_max_7() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -3964,7 +3964,7 @@ fn test_containers_small_test_struct_max_7() {
 
 #[test]
 fn test_containers_bits_struct_zero_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -3980,7 +3980,7 @@ fn test_containers_bits_struct_zero_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7aa68d25017352ef95142af2bb269ce805269676da6111d74887aa9cdcb072a4");
     assert_eq!(root, expected_root);
@@ -3988,7 +3988,7 @@ fn test_containers_bits_struct_zero_2() {
 
 #[test]
 fn test_containers_var_test_struct_random_9() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 36289,
         b: List::<u16, 1024>::from_iter([
             15770, 34869, 26310, 3628, 24227, 36802, 9331, 13524, 8151, 1295, 18640, 24073, 3542,
@@ -4010,7 +4010,7 @@ fn test_containers_var_test_struct_random_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("496d0493780bb91c6ced1e11510a1e2c494ac1eb16e3bf293dfdadaf834958c7");
     assert_eq!(root, expected_root);
@@ -4018,7 +4018,7 @@ fn test_containers_var_test_struct_random_9() {
 
 #[test]
 fn test_containers_var_test_struct_random_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 9142,
         b: List::<u16, 1024>::from_iter([
             22416, 223, 7972, 11484, 19434, 28447, 5231, 56724, 51306, 42521, 27147, 49964, 36706,
@@ -4087,7 +4087,7 @@ fn test_containers_var_test_struct_random_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3c833af82f46636a42cfa718c0e9b287f4e26fa14c0f32a1a7674eaf10347707");
     assert_eq!(root, expected_root);
@@ -4095,7 +4095,7 @@ fn test_containers_var_test_struct_random_0() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, true, true, true, true]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -4111,7 +4111,7 @@ fn test_containers_bits_struct_lengthy_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("39bb190acc9f76e94c785e87e6d20235be64a0d8913fad03cabcf7ec6929e005");
     assert_eq!(root, expected_root);
@@ -4119,7 +4119,7 @@ fn test_containers_bits_struct_lengthy_0() {
 
 #[test]
 fn test_containers_var_test_struct_random_7() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 15141,
         b: List::<u16, 1024>::from_iter([
             11492, 62534, 29650, 54155, 42383, 41747, 4722, 64781, 28665, 7575, 43451, 64198,
@@ -4168,7 +4168,7 @@ fn test_containers_var_test_struct_random_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fdec9924b0923e29f38cef674bb14550bb6ae3ad82afa514c8f0f9fd5b9f1501");
     assert_eq!(root, expected_root);
@@ -4176,7 +4176,7 @@ fn test_containers_var_test_struct_random_7() {
 
 #[test]
 fn test_containers_bits_struct_nil_chaos_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -4192,7 +4192,7 @@ fn test_containers_bits_struct_nil_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b54cbc74cccfac2ac02868b7442271e3e0e98533c9a409529c183874e742f416");
     assert_eq!(root, expected_root);
@@ -4200,7 +4200,7 @@ fn test_containers_bits_struct_nil_chaos_1() {
 
 #[test]
 fn test_containers_small_test_struct_max_9() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_9/serialized.ssz_snappy",
@@ -4210,7 +4210,7 @@ fn test_containers_small_test_struct_max_9() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -4218,7 +4218,7 @@ fn test_containers_small_test_struct_max_9() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_7() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, false, false, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -4234,7 +4234,7 @@ fn test_containers_bits_struct_lengthy_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e7156a8ddcb2f1c71a736c1fa3e5e429bd70dac43c624261774a506fd0bf9091");
     assert_eq!(root, expected_root);
@@ -4242,7 +4242,7 @@ fn test_containers_bits_struct_lengthy_7() {
 
 #[test]
 fn test_containers_var_test_struct_nil_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 54253,
         b: List::<u16, 1024>::from_iter([]),
         c: 113,
@@ -4256,7 +4256,7 @@ fn test_containers_var_test_struct_nil_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("393695f7c96d59344d2c9ac1877e32143abf12828b1cf629876140699d66b84f");
     assert_eq!(root, expected_root);
@@ -4264,7 +4264,7 @@ fn test_containers_var_test_struct_nil_2() {
 
 #[test]
 fn test_containers_complex_test_struct_random_9() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 11787,
         b: List::<u16, 128>::from_iter([
             8531, 23602, 46945, 14476, 64645, 50631, 21162, 24632, 45653, 45856, 24236, 2463,
@@ -4438,7 +4438,7 @@ fn test_containers_complex_test_struct_random_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ef116345d1d809e3a8c2fde4dae330d025ce3d5afbd096ca0477bde166093560");
     assert_eq!(root, expected_root);
@@ -4446,7 +4446,7 @@ fn test_containers_complex_test_struct_random_9() {
 
 #[test]
 fn test_containers_bits_struct_one_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -4462,7 +4462,7 @@ fn test_containers_bits_struct_one_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("41c895a709caea4c3e74ef7bafafb1cb189eae3298ab2817c28ce78444488545");
     assert_eq!(root, expected_root);
@@ -4470,7 +4470,7 @@ fn test_containers_bits_struct_one_1() {
 
 #[test]
 fn test_containers_var_test_struct_nil_5() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 33408,
         b: List::<u16, 1024>::from_iter([]),
         c: 65,
@@ -4484,7 +4484,7 @@ fn test_containers_var_test_struct_nil_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d97827015e4a4920cb11833893aafdf4335e4495a69b7ac9aa4bb9e2282f2077");
     assert_eq!(root, expected_root);
@@ -4492,7 +4492,7 @@ fn test_containers_var_test_struct_nil_5() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_9() {
-    let value = SingleFieldTestStruct { a: 8 };
+    let mut value = SingleFieldTestStruct { a: 8 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_9/serialized.ssz_snappy",
@@ -4502,7 +4502,7 @@ fn test_containers_single_field_test_struct_random_9() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0800000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -4510,7 +4510,7 @@ fn test_containers_single_field_test_struct_random_9() {
 
 #[test]
 fn test_containers_bits_struct_one_6() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -4526,7 +4526,7 @@ fn test_containers_bits_struct_one_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("317370e20fa26f536091dafc94282aa86db552df4ac30045150d4bcd2cc49426");
     assert_eq!(root, expected_root);
@@ -4534,7 +4534,7 @@ fn test_containers_bits_struct_one_6() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_chaos_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 1866,
         b: List::<u16, 1024>::from_iter([
             5970, 16331, 6233, 25696, 43712, 34308, 6378, 53193, 12729, 41143, 28218, 28244, 12683,
@@ -4632,7 +4632,7 @@ fn test_containers_var_test_struct_lengthy_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8f429bf1e545075721c16851b18e1a739991404141ef08e63d23ecfadab79d41");
     assert_eq!(root, expected_root);
@@ -4640,7 +4640,7 @@ fn test_containers_var_test_struct_lengthy_chaos_2() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_0() {
-    let value = SingleFieldTestStruct { a: 225 };
+    let mut value = SingleFieldTestStruct { a: 225 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_0/serialized.ssz_snappy",
@@ -4650,7 +4650,7 @@ fn test_containers_single_field_test_struct_random_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -4658,7 +4658,7 @@ fn test_containers_single_field_test_struct_random_0() {
 
 #[test]
 fn test_containers_complex_test_struct_random_7() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 1062,
         b: List::<u16, 128>::from_iter([
             7871, 15592, 44564, 58127, 25646, 24396, 9801, 25517, 30144, 20664, 5792, 56306, 64674,
@@ -4863,7 +4863,7 @@ fn test_containers_complex_test_struct_random_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("423f3f5a0661f71ca55f045f87ab19265d7b53c701a438893ac630277c2faea0");
     assert_eq!(root, expected_root);
@@ -4871,7 +4871,7 @@ fn test_containers_complex_test_struct_random_7() {
 
 #[test]
 fn test_containers_small_test_struct_random_chaos_1() {
-    let value = SmallTestStruct { a: 59426, b: 2529 };
+    let mut value = SmallTestStruct { a: 59426, b: 2529 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_chaos_1/serialized.ssz_snappy",
@@ -4881,7 +4881,7 @@ fn test_containers_small_test_struct_random_chaos_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d7d8effdbcd60412d8b8affe2aaeeb6a6252256055f4efe4e54863bb9bf940f5");
     assert_eq!(root, expected_root);
@@ -4889,7 +4889,7 @@ fn test_containers_small_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_max_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -4905,7 +4905,7 @@ fn test_containers_bits_struct_max_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9a3d0c2e21e801c79164317f02379726734baa7c163bbe5a1f9c34055113a8bd");
     assert_eq!(root, expected_root);
@@ -4913,7 +4913,7 @@ fn test_containers_bits_struct_max_2() {
 
 #[test]
 fn test_containers_complex_test_struct_random_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 45098,
         b: List::<u16, 128>::from_iter([24760, 11575, 2534, 13704, 55254]),
         c: 96,
@@ -5133,7 +5133,7 @@ fn test_containers_complex_test_struct_random_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e3fbf979c708d4d77adc452ca27d02e9cd978f3fc28601fc75c929b9f1821705");
     assert_eq!(root, expected_root);
@@ -5141,7 +5141,7 @@ fn test_containers_complex_test_struct_random_0() {
 
 #[test]
 fn test_containers_bits_struct_one_8() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -5157,7 +5157,7 @@ fn test_containers_bits_struct_one_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ddc21ccafde9998af8e3fd39a744f1b4d1a08b64e49c9eb7f6137d8e04c07512");
     assert_eq!(root, expected_root);
@@ -5165,7 +5165,7 @@ fn test_containers_bits_struct_one_8() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_7() {
-    let value = SingleFieldTestStruct { a: 181 };
+    let mut value = SingleFieldTestStruct { a: 181 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_7/serialized.ssz_snappy",
@@ -5175,7 +5175,7 @@ fn test_containers_single_field_test_struct_random_7() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b500000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5183,7 +5183,7 @@ fn test_containers_single_field_test_struct_random_7() {
 
 #[test]
 fn test_containers_bits_struct_max_5() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -5199,7 +5199,7 @@ fn test_containers_bits_struct_max_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7b1d842462bfa92850d7e7bfbf6042416e2a0cffdf850987712212d33142e8c4");
     assert_eq!(root, expected_root);
@@ -5207,7 +5207,7 @@ fn test_containers_bits_struct_max_5() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_chaos_1() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -5221,7 +5221,7 @@ fn test_containers_fixed_test_struct_max_chaos_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -5229,7 +5229,7 @@ fn test_containers_fixed_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_random_6() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 64476,
         b: List::<u16, 1024>::from_iter([
             53688, 48973, 58629, 2535, 50734, 12116, 62095, 53745, 26049, 52022, 56676, 54631,
@@ -5249,7 +5249,7 @@ fn test_containers_var_test_struct_random_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("42f6b3f1963d18c3bca3c22c8fbb50df79b0a55b016591fb42d2e3428d9b334d");
     assert_eq!(root, expected_root);
@@ -5257,7 +5257,7 @@ fn test_containers_var_test_struct_random_6() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_6() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true, false, true]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -5273,7 +5273,7 @@ fn test_containers_bits_struct_lengthy_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("26545a0284e45121d8699e25f19fc9c1c4c41112144013c50472a663e9dec051");
     assert_eq!(root, expected_root);
@@ -5281,7 +5281,7 @@ fn test_containers_bits_struct_lengthy_6() {
 
 #[test]
 fn test_containers_bits_struct_nil_chaos_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -5297,7 +5297,7 @@ fn test_containers_bits_struct_nil_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("91aca4bfc8c7a312ed9834decb0c9b2fd8b7f8c6128ac236382a22513df732a1");
     assert_eq!(root, expected_root);
@@ -5305,7 +5305,7 @@ fn test_containers_bits_struct_nil_chaos_0() {
 
 #[test]
 fn test_containers_small_test_struct_max_8() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_8/serialized.ssz_snappy",
@@ -5315,7 +5315,7 @@ fn test_containers_small_test_struct_max_8() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -5323,7 +5323,7 @@ fn test_containers_small_test_struct_max_8() {
 
 #[test]
 fn test_containers_var_test_struct_one_chaos_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 7706,
         b: List::<u16, 1024>::from_iter([40992]),
         c: 148,
@@ -5337,7 +5337,7 @@ fn test_containers_var_test_struct_one_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f51f249688539a42ee372275ec980a4ff15647920a2215f6c572c3d178058275");
     assert_eq!(root, expected_root);
@@ -5345,7 +5345,7 @@ fn test_containers_var_test_struct_one_chaos_2() {
 
 #[test]
 fn test_containers_var_test_struct_random_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 43634,
         b: List::<u16, 1024>::from_iter([
             55593, 62281, 4908, 59811, 54631, 42687, 27754, 27273, 26194, 35717, 1605, 53917, 4007,
@@ -5417,7 +5417,7 @@ fn test_containers_var_test_struct_random_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("19b0167346cd2f1c984be3174c47724ddc1137b403532b6b12158e8005cf1539");
     assert_eq!(root, expected_root);
@@ -5425,7 +5425,7 @@ fn test_containers_var_test_struct_random_1() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, true, false, false, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -5441,7 +5441,7 @@ fn test_containers_bits_struct_lengthy_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("105a099af0fed50f5972d242475878035e14d2322e5c2a12e8ac5cc41cdc9dbe");
     assert_eq!(root, expected_root);
@@ -5449,7 +5449,7 @@ fn test_containers_bits_struct_lengthy_1() {
 
 #[test]
 fn test_containers_small_test_struct_max_6() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_6/serialized.ssz_snappy",
@@ -5459,7 +5459,7 @@ fn test_containers_small_test_struct_max_6() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -5467,7 +5467,7 @@ fn test_containers_small_test_struct_max_6() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_8() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true, false, true]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -5483,7 +5483,7 @@ fn test_containers_bits_struct_lengthy_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("50c9c0adb3b583620b03914e9d06233cebfdc185c0b1dd3be2a00fe64d16d015");
     assert_eq!(root, expected_root);
@@ -5491,7 +5491,7 @@ fn test_containers_bits_struct_lengthy_8() {
 
 #[test]
 fn test_containers_var_test_struct_zero_3() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -5527,7 +5527,7 @@ fn test_containers_var_test_struct_zero_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("21a89163d6419cf2b1b80f4371602341016505eba8a183eebac76841fc29a77d");
     assert_eq!(root, expected_root);
@@ -5535,7 +5535,7 @@ fn test_containers_var_test_struct_zero_3() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_chaos_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -5621,7 +5621,7 @@ fn test_containers_complex_test_struct_zero_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0ec955700f739bb044257ec65d06df9ba2b4028dc074362e9ae558e313896af0");
     assert_eq!(root, expected_root);
@@ -5629,7 +5629,7 @@ fn test_containers_complex_test_struct_zero_chaos_2() {
 
 #[test]
 fn test_containers_var_test_struct_random_8() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 27146,
         b: List::<u16, 1024>::from_iter([
             22447, 64070, 3185, 62696, 47496, 19881, 59400, 35567, 8927, 12773, 18897, 10230,
@@ -5651,7 +5651,7 @@ fn test_containers_var_test_struct_random_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2b40e3ede4edeb7bd1809b6b360acd0929eeea5556de2886b75b946058eccf94");
     assert_eq!(root, expected_root);
@@ -5659,7 +5659,7 @@ fn test_containers_var_test_struct_random_8() {
 
 #[test]
 fn test_containers_bits_struct_zero_3() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -5675,7 +5675,7 @@ fn test_containers_bits_struct_zero_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a08e590982dffd5e3b7a9410c9d86d152cfb2d342bd00eec228aab3e3c5ef64b");
     assert_eq!(root, expected_root);
@@ -5683,7 +5683,7 @@ fn test_containers_bits_struct_zero_3() {
 
 #[test]
 fn test_containers_var_test_struct_zero_4() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -5714,7 +5714,7 @@ fn test_containers_var_test_struct_zero_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("95043ab51c19af41709a41bcecfe6b3efafc1eacf1ac3ea4185c0d26f175584f");
     assert_eq!(root, expected_root);
@@ -5722,7 +5722,7 @@ fn test_containers_var_test_struct_zero_4() {
 
 #[test]
 fn test_containers_small_test_struct_max_1() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_1/serialized.ssz_snappy",
@@ -5732,7 +5732,7 @@ fn test_containers_small_test_struct_max_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -5740,7 +5740,7 @@ fn test_containers_small_test_struct_max_1() {
 
 #[test]
 fn test_containers_bits_struct_zero_4() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -5756,7 +5756,7 @@ fn test_containers_bits_struct_zero_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7a14e144cf89605fa98f03d5315652596c9607d815e162b2d371d7bad872012d");
     assert_eq!(root, expected_root);
@@ -5764,7 +5764,7 @@ fn test_containers_bits_struct_zero_4() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_6() {
-    let value = SingleFieldTestStruct { a: 50 };
+    let mut value = SingleFieldTestStruct { a: 50 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_6/serialized.ssz_snappy",
@@ -5774,7 +5774,7 @@ fn test_containers_single_field_test_struct_random_6() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3200000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5782,7 +5782,7 @@ fn test_containers_single_field_test_struct_random_6() {
 
 #[test]
 fn test_containers_complex_test_struct_random_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 10570,
         b: List::<u16, 128>::from_iter([
             25130, 47018, 44501, 60270, 30202, 60019, 979, 5334, 4184, 39381, 16060, 48693, 2177,
@@ -5987,7 +5987,7 @@ fn test_containers_complex_test_struct_random_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7c29a9a223e62fb6fd23a50ee5dab5de6de62ec44f9a9785e203123599b68bc3");
     assert_eq!(root, expected_root);
@@ -5995,7 +5995,7 @@ fn test_containers_complex_test_struct_random_1() {
 
 #[test]
 fn test_containers_bits_struct_one_9() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -6011,7 +6011,7 @@ fn test_containers_bits_struct_one_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6d9ba4547518645f70c84b158d170837d2a6627f4dc9b851f46d2487b3b94af4");
     assert_eq!(root, expected_root);
@@ -6019,7 +6019,7 @@ fn test_containers_bits_struct_one_9() {
 
 #[test]
 fn test_containers_bits_struct_max_4() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -6035,7 +6035,7 @@ fn test_containers_bits_struct_max_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c91372ca27e8e68838e9afd761fa5e4adbb48e4a2e2ea9377a863b4c1a41b880");
     assert_eq!(root, expected_root);
@@ -6043,7 +6043,7 @@ fn test_containers_bits_struct_max_4() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_chaos_0() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -6057,7 +6057,7 @@ fn test_containers_fixed_test_struct_max_chaos_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -6065,7 +6065,7 @@ fn test_containers_fixed_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_random_6() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 56082,
         b: List::<u16, 128>::from_iter([
             16100, 22857, 27807, 34340, 18934, 15120, 29987, 2470, 46665, 59647, 31943, 45611,
@@ -6319,7 +6319,7 @@ fn test_containers_complex_test_struct_random_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("171ae6694d194490e836168998f9ee01694f403e9104a36ec8b9ca05df67cdbe");
     assert_eq!(root, expected_root);
@@ -6327,7 +6327,7 @@ fn test_containers_complex_test_struct_random_6() {
 
 #[test]
 fn test_containers_small_test_struct_random_chaos_0() {
-    let value = SmallTestStruct { a: 32656, b: 26218 };
+    let mut value = SmallTestStruct { a: 32656, b: 26218 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_chaos_0/serialized.ssz_snappy",
@@ -6337,7 +6337,7 @@ fn test_containers_small_test_struct_random_chaos_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("42fccd03498ca740c0d81c60d845db06b8b10257b9112411d1863b732810725d");
     assert_eq!(root, expected_root);
@@ -6345,7 +6345,7 @@ fn test_containers_small_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_1() {
-    let value = SingleFieldTestStruct { a: 59 };
+    let mut value = SingleFieldTestStruct { a: 59 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_1/serialized.ssz_snappy",
@@ -6355,7 +6355,7 @@ fn test_containers_single_field_test_struct_random_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3b00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6363,7 +6363,7 @@ fn test_containers_single_field_test_struct_random_1() {
 
 #[test]
 fn test_containers_bits_struct_max_3() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -6379,7 +6379,7 @@ fn test_containers_bits_struct_max_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4ba4cfc5cf2a708b0b5fac027a42fd0d03e25ea79114660a4183a9f8ed7fe70f");
     assert_eq!(root, expected_root);
@@ -6387,7 +6387,7 @@ fn test_containers_bits_struct_max_3() {
 
 #[test]
 fn test_containers_var_test_struct_nil_4() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 28577,
         b: List::<u16, 1024>::from_iter([]),
         c: 222,
@@ -6401,7 +6401,7 @@ fn test_containers_var_test_struct_nil_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1f74745ce203e543c7e2ca93e001fc86755a5aa6cf4a0e3a0f02b516a8764974");
     assert_eq!(root, expected_root);
@@ -6409,7 +6409,7 @@ fn test_containers_var_test_struct_nil_4() {
 
 #[test]
 fn test_containers_bits_struct_one_7() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -6425,7 +6425,7 @@ fn test_containers_bits_struct_one_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ebeb7f15f8e27e619d126d73430a13dadc766ce9ab7cae7b0701dbcf88b8cae3");
     assert_eq!(root, expected_root);
@@ -6433,7 +6433,7 @@ fn test_containers_bits_struct_one_7() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_8() {
-    let value = SingleFieldTestStruct { a: 121 };
+    let mut value = SingleFieldTestStruct { a: 121 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_8/serialized.ssz_snappy",
@@ -6443,7 +6443,7 @@ fn test_containers_single_field_test_struct_random_8() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7900000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6451,7 +6451,7 @@ fn test_containers_single_field_test_struct_random_8() {
 
 #[test]
 fn test_containers_var_test_struct_random_chaos_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 56424,
         b: List::<u16, 1024>::from_iter([
             14923, 5692, 42866, 61765, 4524, 40147, 49185, 62818, 16625, 13626, 26774, 26803,
@@ -6492,7 +6492,7 @@ fn test_containers_var_test_struct_random_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("afc6aa81f584fba24b6c7a0fa73bd1b3bdb09a75dab31d111b62bc9e9850cfae");
     assert_eq!(root, expected_root);
@@ -6500,7 +6500,7 @@ fn test_containers_var_test_struct_random_chaos_2() {
 
 #[test]
 fn test_containers_var_test_struct_nil_3() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 16239,
         b: List::<u16, 1024>::from_iter([]),
         c: 51,
@@ -6514,7 +6514,7 @@ fn test_containers_var_test_struct_nil_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3168dedbcb599653e924a07f395a5e2d2ee0af53acdb1323fcd7d8b5c018c65d");
     assert_eq!(root, expected_root);
@@ -6522,7 +6522,7 @@ fn test_containers_var_test_struct_nil_3() {
 
 #[test]
 fn test_containers_complex_test_struct_random_8() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 20254,
         b: List::<u16, 128>::from_iter([
             20019, 60900, 48556, 15177, 23768, 57178, 35087, 7767, 19440, 595, 14057, 20155, 35173,
@@ -6793,7 +6793,7 @@ fn test_containers_complex_test_struct_random_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c44655c114a8ebcf54bbb672b379a0eb3b8091237000cb806c9e3c664bffe2c5");
     assert_eq!(root, expected_root);
@@ -6801,7 +6801,7 @@ fn test_containers_complex_test_struct_random_8() {
 
 #[test]
 fn test_containers_bits_struct_one_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -6817,7 +6817,7 @@ fn test_containers_bits_struct_one_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1542a289ee369034f9a2bc8b879978a66b396b90cfbcff05168d7acdb3ea78c7");
     assert_eq!(root, expected_root);
@@ -6825,7 +6825,7 @@ fn test_containers_bits_struct_one_0() {
 
 #[test]
 fn test_containers_complex_test_struct_random_chaos_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 38946,
         b: List::<u16, 128>::from_iter([
             5471, 27102, 57450, 14239, 40850, 28804, 29251, 64229, 2817, 698, 12066, 31923, 8627,
@@ -6973,7 +6973,7 @@ fn test_containers_complex_test_struct_random_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("da1d555dbd61054d6102286c29ac6076cac1b835620a76dba49c92812cebd1ef");
     assert_eq!(root, expected_root);
@@ -6981,7 +6981,7 @@ fn test_containers_complex_test_struct_random_chaos_2() {
 
 #[test]
 fn test_containers_var_test_struct_max_3() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -7044,7 +7044,7 @@ fn test_containers_var_test_struct_max_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fee37a3f786fcd9d92d4b79fb1b8582694fde17505f381d69c0b0442ab8a9646");
     assert_eq!(root, expected_root);
@@ -7052,7 +7052,7 @@ fn test_containers_var_test_struct_max_3() {
 
 #[test]
 fn test_containers_var_test_struct_nil_chaos_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 57138,
         b: List::<u16, 1024>::from_iter([]),
         c: 18,
@@ -7066,7 +7066,7 @@ fn test_containers_var_test_struct_nil_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("df3efa5ecdee8b78e276a4019413bb50ce5d8fd8cd1d9907584659732db872c1");
     assert_eq!(root, expected_root);
@@ -7074,7 +7074,7 @@ fn test_containers_var_test_struct_nil_chaos_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_6() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_6/serialized.ssz_snappy",
@@ -7084,7 +7084,7 @@ fn test_containers_fixed_test_struct_zero_6() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -7092,7 +7092,7 @@ fn test_containers_fixed_test_struct_zero_6() {
 
 #[test]
 fn test_containers_var_test_struct_max_4() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -7163,7 +7163,7 @@ fn test_containers_var_test_struct_max_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f43b89ecb1afcea42daf293bdd44f386565d4798ab5dc989b91ccc5964714e36");
     assert_eq!(root, expected_root);
@@ -7171,7 +7171,7 @@ fn test_containers_var_test_struct_max_4() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_chaos_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false, true, true]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -7187,7 +7187,7 @@ fn test_containers_bits_struct_lengthy_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("15e8b95c167c4d5af197499b0109debf87516cab159f1a211fd4f4bdace7d05d");
     assert_eq!(root, expected_root);
@@ -7195,7 +7195,7 @@ fn test_containers_bits_struct_lengthy_chaos_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_1() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_1/serialized.ssz_snappy",
@@ -7205,7 +7205,7 @@ fn test_containers_fixed_test_struct_zero_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -7213,7 +7213,7 @@ fn test_containers_fixed_test_struct_zero_1() {
 
 #[test]
 fn test_containers_bits_struct_one_chaos_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -7229,7 +7229,7 @@ fn test_containers_bits_struct_one_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("63c94f1066c71e7fa926100c20d180831c6db761bb9e8500073cb3cccfb180fb");
     assert_eq!(root, expected_root);
@@ -7237,7 +7237,7 @@ fn test_containers_bits_struct_one_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_one_9() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 34750,
         b: List::<u16, 1024>::from_iter([11259]),
         c: 43,
@@ -7251,7 +7251,7 @@ fn test_containers_var_test_struct_one_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("585294982a9f2210cc413c2c211b1564eec730eaf550a08db0d3a6c0308083f4");
     assert_eq!(root, expected_root);
@@ -7259,7 +7259,7 @@ fn test_containers_var_test_struct_one_9() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_8() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_8/serialized.ssz_snappy",
@@ -7269,7 +7269,7 @@ fn test_containers_fixed_test_struct_zero_8() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -7277,7 +7277,7 @@ fn test_containers_fixed_test_struct_zero_8() {
 
 #[test]
 fn test_containers_var_test_struct_one_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 61255,
         b: List::<u16, 1024>::from_iter([17467]),
         c: 65,
@@ -7291,7 +7291,7 @@ fn test_containers_var_test_struct_one_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("263402ff6691e913333141841d14b9a4d4f7b1b08d83f07d57a4638babfcb6ce");
     assert_eq!(root, expected_root);
@@ -7299,7 +7299,7 @@ fn test_containers_var_test_struct_one_0() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_5() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 15159,
         b: List::<u16, 1024>::from_iter([
             40266, 41646, 61275, 56828, 55784, 13765, 5796, 17724, 49215, 57779, 48446, 61955,
@@ -7397,7 +7397,7 @@ fn test_containers_var_test_struct_lengthy_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c1155932fbf4dfa2b35cb98acc09f52cde342511a72a66655dd4d71c748efaf8");
     assert_eq!(root, expected_root);
@@ -7405,7 +7405,7 @@ fn test_containers_var_test_struct_lengthy_5() {
 
 #[test]
 fn test_containers_bits_struct_nil_3() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -7421,7 +7421,7 @@ fn test_containers_bits_struct_nil_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4c2527b09791d6a951c4dc5a5a2a7c441856d5473dcac3cb138b04a891f599e2");
     assert_eq!(root, expected_root);
@@ -7429,7 +7429,7 @@ fn test_containers_bits_struct_nil_3() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 6378,
         b: List::<u16, 1024>::from_iter([
             56213, 56690, 5490, 50070, 64104, 50125, 17654, 6411, 61997, 28536, 45501, 33550,
@@ -7527,7 +7527,7 @@ fn test_containers_var_test_struct_lengthy_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff4561a4611b946e3422adc157c64abd3ada3013475eb8d6f2920e5c6376481a");
     assert_eq!(root, expected_root);
@@ -7535,7 +7535,7 @@ fn test_containers_var_test_struct_lengthy_2() {
 
 #[test]
 fn test_containers_var_test_struct_one_7() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 14149,
         b: List::<u16, 1024>::from_iter([16482]),
         c: 230,
@@ -7549,7 +7549,7 @@ fn test_containers_var_test_struct_one_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("92f9dcdd18f4dc0f8641862bd82cdf4081aefeb974f36bc74cda484ce7dc6637");
     assert_eq!(root, expected_root);
@@ -7557,7 +7557,7 @@ fn test_containers_var_test_struct_one_7() {
 
 #[test]
 fn test_containers_bits_struct_nil_4() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -7573,7 +7573,7 @@ fn test_containers_bits_struct_nil_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a4c710723bb49c0db44a70044fa725642f265b6c9d1cce288f8d40c42a294c1c");
     assert_eq!(root, expected_root);
@@ -7581,7 +7581,7 @@ fn test_containers_bits_struct_nil_4() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 63134,
         b: List::<u16, 128>::from_iter([
             15027, 15033, 56026, 45017, 4982, 62406, 9561, 49872, 52603, 11592, 55880, 4782, 36171,
@@ -7935,7 +7935,7 @@ fn test_containers_complex_test_struct_lengthy_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8edf67843395b2619b3d98e675e5a533be437a2164391889399bba6e4e8f5c46");
     assert_eq!(root, expected_root);
@@ -7943,7 +7943,7 @@ fn test_containers_complex_test_struct_lengthy_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_4() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 141,
         b: 14877529853037520628,
         c: 761682555,
@@ -7957,7 +7957,7 @@ fn test_containers_fixed_test_struct_random_4() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3dd95177bc95d33d840bde460ca0c86b483a15e51f0a0eabe1998f05df5c7edd");
     assert_eq!(root, expected_root);
@@ -7965,7 +7965,7 @@ fn test_containers_fixed_test_struct_random_4() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_6() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 3811,
         b: List::<u16, 128>::from_iter([
             53668, 15579, 54351, 30460, 22734, 24817, 58067, 27093, 43172, 7583, 31508, 17987,
@@ -8319,7 +8319,7 @@ fn test_containers_complex_test_struct_lengthy_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4741272dc08836f02aa60f80fa5406f123bc608906860f276af418b525c49756");
     assert_eq!(root, expected_root);
@@ -8327,7 +8327,7 @@ fn test_containers_complex_test_struct_lengthy_6() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_3() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 72,
         b: 5633501076518207946,
         c: 170036136,
@@ -8341,7 +8341,7 @@ fn test_containers_fixed_test_struct_random_3() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("14e08728743971dd0ac92ca94864067b449c28e91d3dcebd6b5f47df98697acb");
     assert_eq!(root, expected_root);
@@ -8349,7 +8349,7 @@ fn test_containers_fixed_test_struct_random_3() {
 
 #[test]
 fn test_containers_small_test_struct_random_5() {
-    let value = SmallTestStruct { a: 61066, b: 8987 };
+    let mut value = SmallTestStruct { a: 61066, b: 8987 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_5/serialized.ssz_snappy",
@@ -8359,7 +8359,7 @@ fn test_containers_small_test_struct_random_5() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b056a7a8da6c09c77b17d34126d6cf3c772d818c6893ca5c4ea512be7ab55d88");
     assert_eq!(root, expected_root);
@@ -8367,7 +8367,7 @@ fn test_containers_small_test_struct_random_5() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_8() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 19399,
         b: List::<u16, 128>::from_iter([
             22032, 62371, 21788, 9932, 54144, 27131, 3242, 54591, 47647, 13046, 29529, 13141,
@@ -8720,7 +8720,7 @@ fn test_containers_complex_test_struct_lengthy_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cf3761ba9461b1af5158ea2e93141841e86368e57dc089d80fded1e1f7750866");
     assert_eq!(root, expected_root);
@@ -8728,7 +8728,7 @@ fn test_containers_complex_test_struct_lengthy_8() {
 
 #[test]
 fn test_containers_small_test_struct_random_2() {
-    let value = SmallTestStruct { a: 23998, b: 14996 };
+    let mut value = SmallTestStruct { a: 23998, b: 14996 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_2/serialized.ssz_snappy",
@@ -8738,7 +8738,7 @@ fn test_containers_small_test_struct_random_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6c014ce952c149ee0484856ca5f90db0015b6fcc6afd4dd5fa8f3354ea32f427");
     assert_eq!(root, expected_root);
@@ -8746,7 +8746,7 @@ fn test_containers_small_test_struct_random_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_max() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -8760,7 +8760,7 @@ fn test_containers_fixed_test_struct_max() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -8768,7 +8768,7 @@ fn test_containers_fixed_test_struct_max() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_3() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 53621,
         b: List::<u16, 1024>::from_iter([
             12824, 63199, 12227, 37027, 24572, 53189, 4389, 44798, 43145, 8174, 43110, 30174,
@@ -8866,7 +8866,7 @@ fn test_containers_var_test_struct_lengthy_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ac826d5dd43427c8f4838bf5b54134ce4ddf37a6a9bcea07d229964940858853");
     assert_eq!(root, expected_root);
@@ -8874,7 +8874,7 @@ fn test_containers_var_test_struct_lengthy_3() {
 
 #[test]
 fn test_containers_var_test_struct_one_6() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 5264,
         b: List::<u16, 1024>::from_iter([12220]),
         c: 50,
@@ -8888,7 +8888,7 @@ fn test_containers_var_test_struct_one_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("14662980605e77baa6e07639d5bbe81467e2ca249340e9531edcaa87585cedab");
     assert_eq!(root, expected_root);
@@ -8896,7 +8896,7 @@ fn test_containers_var_test_struct_one_6() {
 
 #[test]
 fn test_containers_bits_struct_nil_5() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -8912,7 +8912,7 @@ fn test_containers_bits_struct_nil_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("51e74ba89a64b57dcb64384a1ba81c8ac3e15edfec97f187e20dfa5669859035");
     assert_eq!(root, expected_root);
@@ -8920,7 +8920,7 @@ fn test_containers_bits_struct_nil_5() {
 
 #[test]
 fn test_containers_var_test_struct_one_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 47389,
         b: List::<u16, 1024>::from_iter([45887]),
         c: 140,
@@ -8934,7 +8934,7 @@ fn test_containers_var_test_struct_one_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("90fc29dbcb37509bde9cbecb990e7fb5ead6249d16964870263e7b58c57ba7cb");
     assert_eq!(root, expected_root);
@@ -8942,7 +8942,7 @@ fn test_containers_var_test_struct_one_1() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_4() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 49542,
         b: List::<u16, 1024>::from_iter([
             24176, 6691, 23594, 34600, 279, 42247, 61589, 7750, 35436, 7515, 9624, 33952, 31649,
@@ -9040,7 +9040,7 @@ fn test_containers_var_test_struct_lengthy_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8c5021941ca0553eaff53a2b56b2ff86bee1249c77c700d3f47406569bd0b01f");
     assert_eq!(root, expected_root);
@@ -9048,7 +9048,7 @@ fn test_containers_var_test_struct_lengthy_4() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_chaos_2() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_chaos_2/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -9056,7 +9056,7 @@ fn test_containers_single_field_test_struct_zero_chaos_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9064,7 +9064,7 @@ fn test_containers_single_field_test_struct_zero_chaos_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_9() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_9/serialized.ssz_snappy",
@@ -9074,7 +9074,7 @@ fn test_containers_fixed_test_struct_zero_9() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -9082,7 +9082,7 @@ fn test_containers_fixed_test_struct_zero_9() {
 
 #[test]
 fn test_containers_bits_struct_nil_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -9098,7 +9098,7 @@ fn test_containers_bits_struct_nil_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6624f0820a556f057e3fbe2cc01793f8b0feab93bba19c642d0aee954d336493");
     assert_eq!(root, expected_root);
@@ -9106,7 +9106,7 @@ fn test_containers_bits_struct_nil_2() {
 
 #[test]
 fn test_containers_complex_test_struct_max_chaos_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -9346,7 +9346,7 @@ fn test_containers_complex_test_struct_max_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5065533e7b56e29e0da6386fa6ab9370faa05722ab0e60080fadf809cf58807a");
     assert_eq!(root, expected_root);
@@ -9354,7 +9354,7 @@ fn test_containers_complex_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_var_test_struct_max_5() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -9391,7 +9391,7 @@ fn test_containers_var_test_struct_max_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5d79a4fe1fc468caab77f2c903262aa8c4ce6756121fca8b25919b0fab711367");
     assert_eq!(root, expected_root);
@@ -9399,7 +9399,7 @@ fn test_containers_var_test_struct_max_5() {
 
 #[test]
 fn test_containers_var_test_struct_one_8() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 32967,
         b: List::<u16, 1024>::from_iter([65174]),
         c: 29,
@@ -9413,7 +9413,7 @@ fn test_containers_var_test_struct_one_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("68282c3fddc3aa7aabbff61772ef621b78adedcaed8b4ccaf1ab7e6b8e01361c");
     assert_eq!(root, expected_root);
@@ -9421,7 +9421,7 @@ fn test_containers_var_test_struct_one_8() {
 
 #[test]
 fn test_containers_bits_struct_one_chaos_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -9437,7 +9437,7 @@ fn test_containers_bits_struct_one_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("64d99ff40982dc77152ffd324add9251d78e4b83fc1a1e466d79a123444bdf8d");
     assert_eq!(root, expected_root);
@@ -9445,7 +9445,7 @@ fn test_containers_bits_struct_one_chaos_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_0() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_0/serialized.ssz_snappy",
@@ -9455,7 +9455,7 @@ fn test_containers_fixed_test_struct_zero_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -9463,7 +9463,7 @@ fn test_containers_fixed_test_struct_zero_0() {
 
 #[test]
 fn test_containers_var_test_struct_max_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -9527,7 +9527,7 @@ fn test_containers_var_test_struct_max_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("728b5cde46644e09809e707f1db6076c692954b8cc589a17884626884f5e05e9");
     assert_eq!(root, expected_root);
@@ -9535,7 +9535,7 @@ fn test_containers_var_test_struct_max_2() {
 
 #[test]
 fn test_containers_small_test_struct_max_chaos_2() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_chaos_2/serialized.ssz_snappy",
@@ -9545,7 +9545,7 @@ fn test_containers_small_test_struct_max_chaos_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -9553,7 +9553,7 @@ fn test_containers_small_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_7() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_7/serialized.ssz_snappy",
@@ -9563,7 +9563,7 @@ fn test_containers_fixed_test_struct_zero_7() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -9571,7 +9571,7 @@ fn test_containers_fixed_test_struct_zero_7() {
 
 #[test]
 fn test_containers_small_test_struct_random_3() {
-    let value = SmallTestStruct { a: 1916, b: 63799 };
+    let mut value = SmallTestStruct { a: 1916, b: 63799 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_3/serialized.ssz_snappy",
@@ -9581,7 +9581,7 @@ fn test_containers_small_test_struct_random_3() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("57841ce63e13790da0b2ff364dbf4a9e2fb95226220689bb070f170197c9a6d6");
     assert_eq!(root, expected_root);
@@ -9589,7 +9589,7 @@ fn test_containers_small_test_struct_random_3() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_9() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 30344,
         b: List::<u16, 128>::from_iter([
             27285, 31750, 46578, 54105, 57571, 43485, 744, 1344, 32473, 47440, 11194, 63789, 51406,
@@ -9943,7 +9943,7 @@ fn test_containers_complex_test_struct_lengthy_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4f851814990c1305f4686cda352ec5c2313a0dff0d960a7a900ce1e2e90f8150");
     assert_eq!(root, expected_root);
@@ -9951,7 +9951,7 @@ fn test_containers_complex_test_struct_lengthy_9() {
 
 #[test]
 fn test_containers_single_field_test_struct_max() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max/serialized.ssz_snappy",
@@ -9961,7 +9961,7 @@ fn test_containers_single_field_test_struct_max() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -9969,7 +9969,7 @@ fn test_containers_single_field_test_struct_max() {
 
 #[test]
 fn test_containers_small_test_struct_random_4() {
-    let value = SmallTestStruct { a: 32745, b: 8462 };
+    let mut value = SmallTestStruct { a: 32745, b: 8462 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_4/serialized.ssz_snappy",
@@ -9979,7 +9979,7 @@ fn test_containers_small_test_struct_random_4() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("864908308d350be5c4591f067a662751434af440702d06685f8a652c07f6c12a");
     assert_eq!(root, expected_root);
@@ -9987,7 +9987,7 @@ fn test_containers_small_test_struct_random_4() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_7() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 30521,
         b: List::<u16, 128>::from_iter([
             10757, 35890, 12515, 50368, 25758, 35190, 25950, 21021, 49712, 38881, 38680, 30011,
@@ -10341,7 +10341,7 @@ fn test_containers_complex_test_struct_lengthy_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("79cd0ec624c402f43dad6d2c2e9c7699ff6c9f59e30455409194db3c2a48ade5");
     assert_eq!(root, expected_root);
@@ -10349,7 +10349,7 @@ fn test_containers_complex_test_struct_lengthy_7() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_2() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 73,
         b: 17290263866691938161,
         c: 3311333766,
@@ -10363,7 +10363,7 @@ fn test_containers_fixed_test_struct_random_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("925af6af4968ef66f299362d6b40cf4164b3e27fbb7e085445f0c9b827e74ccc");
     assert_eq!(root, expected_root);
@@ -10371,7 +10371,7 @@ fn test_containers_fixed_test_struct_random_2() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 34044,
         b: List::<u16, 128>::from_iter([
             48874, 34700, 53776, 29805, 17569, 35418, 43707, 15489, 5164, 33511, 1254, 54569,
@@ -10725,7 +10725,7 @@ fn test_containers_complex_test_struct_lengthy_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d1bb44d6f0a011c83488f0f87c801b8392a35a9e6b78218332de4e193b29dc48");
     assert_eq!(root, expected_root);
@@ -10733,7 +10733,7 @@ fn test_containers_complex_test_struct_lengthy_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_5() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 79,
         b: 14098080771816090726,
         c: 2129688544,
@@ -10747,7 +10747,7 @@ fn test_containers_fixed_test_struct_random_5() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c44c5c18fc468fd2689febc405f521c41a5b5fd6958319e53b1d0f94c5aa238a");
     assert_eq!(root, expected_root);
@@ -10755,7 +10755,7 @@ fn test_containers_fixed_test_struct_random_5() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_8() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -10833,7 +10833,7 @@ fn test_containers_complex_test_struct_zero_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("44aa205a1ab79b3ef1674d4040b34d702efe212440c817248c48beaf73443a45");
     assert_eq!(root, expected_root);
@@ -10841,7 +10841,7 @@ fn test_containers_complex_test_struct_zero_8() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_9() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_9/serialized.ssz_snappy",
@@ -10851,7 +10851,7 @@ fn test_containers_single_field_test_struct_zero_9() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -10859,7 +10859,7 @@ fn test_containers_single_field_test_struct_zero_9() {
 
 #[test]
 fn test_containers_bits_struct_zero_chaos_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -10875,7 +10875,7 @@ fn test_containers_bits_struct_zero_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5b8c65840d6ad9823340ff0108e98f8efa055be1911fc7d7012c5de1064b4caf");
     assert_eq!(root, expected_root);
@@ -10883,7 +10883,7 @@ fn test_containers_bits_struct_zero_chaos_2() {
 
 #[test]
 fn test_containers_bits_struct_random_8() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true, true]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -10899,7 +10899,7 @@ fn test_containers_bits_struct_random_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("de589adc2de052524b60cb01e01ed8a5cc1c24404877b152b1e9154f6393b5bd");
     assert_eq!(root, expected_root);
@@ -10907,7 +10907,7 @@ fn test_containers_bits_struct_random_8() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_5() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_5/serialized.ssz_snappy",
@@ -10917,7 +10917,7 @@ fn test_containers_single_field_test_struct_max_5() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -10925,7 +10925,7 @@ fn test_containers_single_field_test_struct_max_5() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_6() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -11023,7 +11023,7 @@ fn test_containers_complex_test_struct_zero_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a1763935a5d9d806ec0c10b05513374b75fb112f3b82509c1f9326ced4b58b6f");
     assert_eq!(root, expected_root);
@@ -11031,7 +11031,7 @@ fn test_containers_complex_test_struct_zero_6() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_7() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_7/serialized.ssz_snappy",
@@ -11041,7 +11041,7 @@ fn test_containers_single_field_test_struct_zero_7() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -11049,7 +11049,7 @@ fn test_containers_single_field_test_struct_zero_7() {
 
 #[test]
 fn test_containers_bits_struct_random_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -11065,7 +11065,7 @@ fn test_containers_bits_struct_random_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("df0f6d27156f4692278048a9b03fed71e2265fb85a651d685197034ebbce876f");
     assert_eq!(root, expected_root);
@@ -11073,7 +11073,7 @@ fn test_containers_bits_struct_random_1() {
 
 #[test]
 fn test_containers_complex_test_struct_one_chaos_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 16851,
         b: List::<u16, 128>::from_iter([43827]),
         c: 197,
@@ -11127,7 +11127,7 @@ fn test_containers_complex_test_struct_one_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6647355693570b0e372117d77096b3049a5ac71571d706fd486a4814b18c637a");
     assert_eq!(root, expected_root);
@@ -11135,7 +11135,7 @@ fn test_containers_complex_test_struct_one_chaos_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_2() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_2/serialized.ssz_snappy",
@@ -11145,7 +11145,7 @@ fn test_containers_single_field_test_struct_max_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -11153,7 +11153,7 @@ fn test_containers_single_field_test_struct_max_2() {
 
 #[test]
 fn test_containers_bits_struct_random_6() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, true, true, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -11169,7 +11169,7 @@ fn test_containers_bits_struct_random_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3e65520e875a5d0347f9cdf810c1d2c76b33f0606bbf136b9e4d5d17ff87ded9");
     assert_eq!(root, expected_root);
@@ -11177,7 +11177,7 @@ fn test_containers_bits_struct_random_6() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_0() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_0/serialized.ssz_snappy",
@@ -11187,7 +11187,7 @@ fn test_containers_single_field_test_struct_zero_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -11195,7 +11195,7 @@ fn test_containers_single_field_test_struct_zero_0() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -11302,7 +11302,7 @@ fn test_containers_complex_test_struct_zero_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f701b968d59dc21a5e05a33ec5cfa5e46a4090d66d92adf6d3e2b244366b2e8f");
     assert_eq!(root, expected_root);
@@ -11310,7 +11310,7 @@ fn test_containers_complex_test_struct_zero_1() {
 
 #[test]
 fn test_containers_complex_test_struct_max_4() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -11620,7 +11620,7 @@ fn test_containers_complex_test_struct_max_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("869070dd164bec9a6a980ba72829d21004a9df8268033a5f2dc1aa606a43158a");
     assert_eq!(root, expected_root);
@@ -11628,7 +11628,7 @@ fn test_containers_complex_test_struct_max_4() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_chaos_1() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_chaos_1/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -11636,7 +11636,7 @@ fn test_containers_single_field_test_struct_max_chaos_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -11644,7 +11644,7 @@ fn test_containers_single_field_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_chaos_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 6800,
         b: List::<u16, 128>::from_iter([
             36829, 20943, 41561, 60705, 6836, 19276, 13404, 15270, 24787, 32752, 38430, 8083,
@@ -11996,7 +11996,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("079ed404b123f765913f7fddd43bc35e06cbeb8a97c2058564434dd8cf513c3a");
     assert_eq!(root, expected_root);
@@ -12004,7 +12004,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_one_9() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 32826,
         b: List::<u16, 128>::from_iter([52269]),
         c: 179,
@@ -12058,7 +12058,7 @@ fn test_containers_complex_test_struct_one_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b6a6dadc39093cfcbe17d99863ec39be349756cd0e156aa1ecf2edaa6823fab1");
     assert_eq!(root, expected_root);
@@ -12066,7 +12066,7 @@ fn test_containers_complex_test_struct_one_9() {
 
 #[test]
 fn test_containers_bits_struct_random_chaos_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -12082,7 +12082,7 @@ fn test_containers_bits_struct_random_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c89390bf6b5c49e2c42be8203a79bdb6c67780ad00c1e649fea1255335f4244b");
     assert_eq!(root, expected_root);
@@ -12090,7 +12090,7 @@ fn test_containers_bits_struct_random_chaos_2() {
 
 #[test]
 fn test_containers_var_test_struct_zero_chaos_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -12131,7 +12131,7 @@ fn test_containers_var_test_struct_zero_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("037ec5030f962590e3fbdb61d5614e93129138f4fdf5a380dbca64d2a4ac7810");
     assert_eq!(root, expected_root);
@@ -12139,7 +12139,7 @@ fn test_containers_var_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_max_3() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -12349,7 +12349,7 @@ fn test_containers_complex_test_struct_max_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2b5b8b8a2aa2d905a2716be903b7694e03740120db4a613c7d0ba87b171dfe2c");
     assert_eq!(root, expected_root);
@@ -12357,7 +12357,7 @@ fn test_containers_complex_test_struct_max_3() {
 
 #[test]
 fn test_containers_complex_test_struct_one_7() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 46962,
         b: List::<u16, 128>::from_iter([51108]),
         c: 232,
@@ -12411,7 +12411,7 @@ fn test_containers_complex_test_struct_one_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7460458ef6fd374a9de68db7a0b3d0f0d1aed59325725d07a90616456ebcd588");
     assert_eq!(root, expected_root);
@@ -12419,7 +12419,7 @@ fn test_containers_complex_test_struct_one_7() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_chaos_2() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_chaos_2/serialized.ssz_snappy",
@@ -12429,7 +12429,7 @@ fn test_containers_fixed_test_struct_zero_chaos_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -12437,7 +12437,7 @@ fn test_containers_fixed_test_struct_zero_chaos_2() {
 
 #[test]
 fn test_containers_complex_test_struct_one_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 48911,
         b: List::<u16, 128>::from_iter([9378]),
         c: 223,
@@ -12491,7 +12491,7 @@ fn test_containers_complex_test_struct_one_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a02e83c64be6459fb89ee3893623c5767cbec7295e71e887392771ff98603a03");
     assert_eq!(root, expected_root);
@@ -12499,7 +12499,7 @@ fn test_containers_complex_test_struct_one_0() {
 
 #[test]
 fn test_containers_complex_test_struct_one_chaos_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 38015,
         b: List::<u16, 128>::from_iter([22188]),
         c: 189,
@@ -12553,7 +12553,7 @@ fn test_containers_complex_test_struct_one_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a57d86f4ea29cd835b6bc7adf0a5205f1ed819aa736892dd336da3869d857820");
     assert_eq!(root, expected_root);
@@ -12561,7 +12561,7 @@ fn test_containers_complex_test_struct_one_chaos_1() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_3() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_3/serialized.ssz_snappy",
@@ -12571,7 +12571,7 @@ fn test_containers_single_field_test_struct_max_3() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -12579,7 +12579,7 @@ fn test_containers_single_field_test_struct_max_3() {
 
 #[test]
 fn test_containers_bits_struct_random_7() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, false]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -12595,7 +12595,7 @@ fn test_containers_bits_struct_random_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9b29961c7d4a3b73ea66e6adf69a520890e9bedb001b01c3a24b79a0cc135997");
     assert_eq!(root, expected_root);
@@ -12603,7 +12603,7 @@ fn test_containers_bits_struct_random_7() {
 
 #[test]
 fn test_containers_bits_struct_max_chaos_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -12619,7 +12619,7 @@ fn test_containers_bits_struct_max_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("662a52b056d31844fe9a143bc7bf82f6c52d7cc9d6b9d9736c2e0d7c9a4b65f3");
     assert_eq!(root, expected_root);
@@ -12627,7 +12627,7 @@ fn test_containers_bits_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -12718,7 +12718,7 @@ fn test_containers_complex_test_struct_zero_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d3f0fe44a7a2f41215d6fdb22cce2e0c89be118c7a5106ef5bff4290a570ede0");
     assert_eq!(root, expected_root);
@@ -12726,7 +12726,7 @@ fn test_containers_complex_test_struct_zero_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_1() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_1/serialized.ssz_snappy",
@@ -12736,7 +12736,7 @@ fn test_containers_single_field_test_struct_zero_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -12744,7 +12744,7 @@ fn test_containers_single_field_test_struct_zero_1() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_4() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_4/serialized.ssz_snappy",
@@ -12754,7 +12754,7 @@ fn test_containers_single_field_test_struct_max_4() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -12762,7 +12762,7 @@ fn test_containers_single_field_test_struct_max_4() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_6() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_6/serialized.ssz_snappy",
@@ -12772,7 +12772,7 @@ fn test_containers_single_field_test_struct_zero_6() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -12780,7 +12780,7 @@ fn test_containers_single_field_test_struct_zero_6() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_7() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -12884,7 +12884,7 @@ fn test_containers_complex_test_struct_zero_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ecdc839d58de1e9b6003770857a5097dea8c25c6f63078494bee748f7a912b8f");
     assert_eq!(root, expected_root);
@@ -12892,7 +12892,7 @@ fn test_containers_complex_test_struct_zero_7() {
 
 #[test]
 fn test_containers_bits_struct_random_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -12908,7 +12908,7 @@ fn test_containers_bits_struct_random_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("772980f52813d8970bcc933736cd21975517a61483612efd2086591e1b0cdae6");
     assert_eq!(root, expected_root);
@@ -12916,7 +12916,7 @@ fn test_containers_bits_struct_random_0() {
 
 #[test]
 fn test_containers_bits_struct_random_9() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, false, true]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -12932,7 +12932,7 @@ fn test_containers_bits_struct_random_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0c78458e737991adc376b4be7ab7b07522374623557c4ca8abcd00bd8665cd13");
     assert_eq!(root, expected_root);
@@ -12940,7 +12940,7 @@ fn test_containers_bits_struct_random_9() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_8() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_8/serialized.ssz_snappy",
@@ -12950,7 +12950,7 @@ fn test_containers_single_field_test_struct_zero_8() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -12958,7 +12958,7 @@ fn test_containers_single_field_test_struct_zero_8() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_9() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([0, 0, 0]),
         c: 0,
@@ -13066,7 +13066,7 @@ fn test_containers_complex_test_struct_zero_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("eef804ef0a314328f86f7635f913264f4c7a0ce11d8a9e5dc3c400bb8d7a6aa7");
     assert_eq!(root, expected_root);
@@ -13074,7 +13074,7 @@ fn test_containers_complex_test_struct_zero_9() {
 
 #[test]
 fn test_containers_complex_test_struct_one_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 63214,
         b: List::<u16, 128>::from_iter([13623]),
         c: 59,
@@ -13128,7 +13128,7 @@ fn test_containers_complex_test_struct_one_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9e054c2087b21ff5263743e8939a648ec8d6195c7c7dbb4eb38baf2d15e94400");
     assert_eq!(root, expected_root);
@@ -13136,7 +13136,7 @@ fn test_containers_complex_test_struct_one_1() {
 
 #[test]
 fn test_containers_complex_test_struct_one_6() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 51972,
         b: List::<u16, 128>::from_iter([48645]),
         c: 46,
@@ -13190,7 +13190,7 @@ fn test_containers_complex_test_struct_one_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("69b0ce69dfbc8abb8ae4fba564dcb813f5cc5b93c76d2b3d0689687c35821036");
     assert_eq!(root, expected_root);
@@ -13198,7 +13198,7 @@ fn test_containers_complex_test_struct_one_6() {
 
 #[test]
 fn test_containers_complex_test_struct_max_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -13367,7 +13367,7 @@ fn test_containers_complex_test_struct_max_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9660907d6be249c807c9910f05a030bf95e523742de605d1d71b6a73dd5d7697");
     assert_eq!(root, expected_root);
@@ -13375,7 +13375,7 @@ fn test_containers_complex_test_struct_max_2() {
 
 #[test]
 fn test_containers_var_test_struct_zero_chaos_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -13411,7 +13411,7 @@ fn test_containers_var_test_struct_zero_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6d78c67e92d89d5fa157efbff423b287f4940a3bd4e7c7b3800624c42ad10ac6");
     assert_eq!(root, expected_root);
@@ -13419,7 +13419,7 @@ fn test_containers_var_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_max_5() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([65535, 65535, 65535, 65535, 65535]),
         c: 255,
@@ -13698,7 +13698,7 @@ fn test_containers_complex_test_struct_max_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f3caea79b0c0a1756a7596bf0939a6d7495497936461f41d0315ce321d4b3dad");
     assert_eq!(root, expected_root);
@@ -13706,7 +13706,7 @@ fn test_containers_complex_test_struct_max_5() {
 
 #[test]
 fn test_containers_complex_test_struct_one_8() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 43221,
         b: List::<u16, 128>::from_iter([62632]),
         c: 161,
@@ -13760,7 +13760,7 @@ fn test_containers_complex_test_struct_one_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("dc304f765bc1d7f380986aff8ff000690ca7c7932024088083c2646913353701");
     assert_eq!(root, expected_root);
@@ -13768,7 +13768,7 @@ fn test_containers_complex_test_struct_one_8() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_chaos_0() {
-    let value = SingleFieldTestStruct { a: 255 };
+    let mut value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_max_chaos_0/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -13776,7 +13776,7 @@ fn test_containers_single_field_test_struct_max_chaos_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -13784,7 +13784,7 @@ fn test_containers_single_field_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_chaos_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 14153,
         b: List::<u16, 128>::from_iter([
             3646, 43626, 7304, 41108, 40285, 9810, 25903, 50110, 7170, 37407, 23703, 47708, 39247,
@@ -14136,7 +14136,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9e8d9f5d5a03974171cc977eb7fc10305f1bee1b469a11974f25424d8e518773");
     assert_eq!(root, expected_root);
@@ -14144,7 +14144,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_5() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 31744,
         b: List::<u16, 128>::from_iter([]),
         c: 33,
@@ -14198,7 +14198,7 @@ fn test_containers_complex_test_struct_nil_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d3339dcf8b5c37412b46d01fad924e5f5baafbd8ef6fb5e7d32cda58a8184e2c");
     assert_eq!(root, expected_root);
@@ -14206,7 +14206,7 @@ fn test_containers_complex_test_struct_nil_5() {
 
 #[test]
 fn test_containers_var_test_struct_max_chaos_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -14283,7 +14283,7 @@ fn test_containers_var_test_struct_max_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c3e720d29dc4e4baa5cbad059f4eb0b99189c911dcede2863bb5b77795c5cc3d");
     assert_eq!(root, expected_root);
@@ -14291,7 +14291,7 @@ fn test_containers_var_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 51296,
         b: List::<u16, 128>::from_iter([]),
         c: 24,
@@ -14345,7 +14345,7 @@ fn test_containers_complex_test_struct_nil_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3009a7b09039d85079b9a29358d237bbd3fbeb4c25d05bc9da326188342995a3");
     assert_eq!(root, expected_root);
@@ -14353,7 +14353,7 @@ fn test_containers_complex_test_struct_nil_2() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_chaos_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 16389,
         b: List::<u16, 128>::from_iter([]),
         c: 229,
@@ -14407,7 +14407,7 @@ fn test_containers_complex_test_struct_nil_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b89f29dc5910fc88db50b3b75245371c139f5f927a522da5ad4ac100a40aae77");
     assert_eq!(root, expected_root);
@@ -14415,7 +14415,7 @@ fn test_containers_complex_test_struct_nil_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_max() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -14455,7 +14455,7 @@ fn test_containers_var_test_struct_max() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d9824eb3449dabb9f62c69e72c5e5ba5917a1d68e679557e3fd1cb0cfdc38d17");
     assert_eq!(root, expected_root);
@@ -14463,7 +14463,7 @@ fn test_containers_var_test_struct_max() {
 
 #[test]
 fn test_containers_small_test_struct_zero_4() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_4/serialized.ssz_snappy",
@@ -14473,7 +14473,7 @@ fn test_containers_small_test_struct_zero_4() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -14481,7 +14481,7 @@ fn test_containers_small_test_struct_zero_4() {
 
 #[test]
 fn test_containers_small_test_struct_zero_3() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_3/serialized.ssz_snappy",
@@ -14491,7 +14491,7 @@ fn test_containers_small_test_struct_zero_3() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -14499,7 +14499,7 @@ fn test_containers_small_test_struct_zero_3() {
 
 #[test]
 fn test_containers_bits_struct_zero() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -14515,7 +14515,7 @@ fn test_containers_bits_struct_zero() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7aa68d25017352ef95142af2bb269ce805269676da6111d74887aa9cdcb072a4");
     assert_eq!(root, expected_root);
@@ -14523,7 +14523,7 @@ fn test_containers_bits_struct_zero() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_2() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -14537,7 +14537,7 @@ fn test_containers_fixed_test_struct_max_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -14545,7 +14545,7 @@ fn test_containers_fixed_test_struct_max_2() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_chaos_0() {
-    let value = SingleFieldTestStruct { a: 15 };
+    let mut value = SingleFieldTestStruct { a: 15 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_chaos_0/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -14553,7 +14553,7 @@ fn test_containers_single_field_test_struct_random_chaos_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0f00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -14561,7 +14561,7 @@ fn test_containers_single_field_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_5() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -14575,7 +14575,7 @@ fn test_containers_fixed_test_struct_max_5() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -14583,7 +14583,7 @@ fn test_containers_fixed_test_struct_max_5() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_chaos_0() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 162,
         b: 17433115223182371175,
         c: 867140057,
@@ -14597,7 +14597,7 @@ fn test_containers_fixed_test_struct_random_chaos_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("dc82cc007c637f89a9b7ba1c446f17f598663637c51c774d3b988b5f27d6556c");
     assert_eq!(root, expected_root);
@@ -14605,7 +14605,7 @@ fn test_containers_fixed_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_small_test_struct_zero_chaos_1() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_chaos_1/serialized.ssz_snappy",
@@ -14615,7 +14615,7 @@ fn test_containers_small_test_struct_zero_chaos_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -14623,7 +14623,7 @@ fn test_containers_small_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_zero() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14650,7 +14650,7 @@ fn test_containers_var_test_struct_zero() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7b7591e4bc71e165eadd3cab254795eb03ce695be7e531a9e601bc3327c3fd6e");
     assert_eq!(root, expected_root);
@@ -14658,7 +14658,7 @@ fn test_containers_var_test_struct_zero() {
 
 #[test]
 fn test_containers_small_test_struct_zero_2() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_2/serialized.ssz_snappy",
@@ -14668,7 +14668,7 @@ fn test_containers_small_test_struct_zero_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -14676,7 +14676,7 @@ fn test_containers_small_test_struct_zero_2() {
 
 #[test]
 fn test_containers_small_test_struct_zero_5() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_5/serialized.ssz_snappy",
@@ -14686,7 +14686,7 @@ fn test_containers_small_test_struct_zero_5() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -14694,7 +14694,7 @@ fn test_containers_small_test_struct_zero_5() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_3() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 59736,
         b: List::<u16, 128>::from_iter([]),
         c: 120,
@@ -14748,7 +14748,7 @@ fn test_containers_complex_test_struct_nil_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("39b4d31246afbdb07fd955fdf5d982bd832714cbed6666fd7ef47379cf947275");
     assert_eq!(root, expected_root);
@@ -14756,7 +14756,7 @@ fn test_containers_complex_test_struct_nil_3() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_chaos_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 6980,
         b: List::<u16, 128>::from_iter([]),
         c: 27,
@@ -14810,7 +14810,7 @@ fn test_containers_complex_test_struct_nil_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5bc8bd92a0d88a9a3b388b7109e8294ec4c24fd9e2ccc6fd9021c36a2acf77df");
     assert_eq!(root, expected_root);
@@ -14818,7 +14818,7 @@ fn test_containers_complex_test_struct_nil_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_max_chaos_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -14842,7 +14842,7 @@ fn test_containers_var_test_struct_max_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fd31fbb40e94c30fa8fe09c0055e48d66a2d142c1a3213086d902067eaa8b8de");
     assert_eq!(root, expected_root);
@@ -14850,7 +14850,7 @@ fn test_containers_var_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_4() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 44905,
         b: List::<u16, 128>::from_iter([]),
         c: 144,
@@ -14904,7 +14904,7 @@ fn test_containers_complex_test_struct_nil_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fcad01afa41478c73d86c160078d557a11aec6425bdd91de7909ad735e8b2151");
     assert_eq!(root, expected_root);
@@ -14912,7 +14912,7 @@ fn test_containers_complex_test_struct_nil_4() {
 
 #[test]
 fn test_containers_small_test_struct_zero_chaos_0() {
-    let value = SmallTestStruct { a: 0, b: 0 };
+    let mut value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_zero_chaos_0/serialized.ssz_snappy",
@@ -14922,7 +14922,7 @@ fn test_containers_small_test_struct_zero_chaos_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -14930,7 +14930,7 @@ fn test_containers_small_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_chaos_1() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 203,
         b: 7769282278803472418,
         c: 872994431,
@@ -14944,7 +14944,7 @@ fn test_containers_fixed_test_struct_random_chaos_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b4bd04eda485b869dcaebd603d86834d9e70885e7e061df343aaf753f4252267");
     assert_eq!(root, expected_root);
@@ -14952,7 +14952,7 @@ fn test_containers_fixed_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_4() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -14966,7 +14966,7 @@ fn test_containers_fixed_test_struct_max_4() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -14974,7 +14974,7 @@ fn test_containers_fixed_test_struct_max_4() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_chaos_1() {
-    let value = SingleFieldTestStruct { a: 8 };
+    let mut value = SingleFieldTestStruct { a: 8 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_chaos_1/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -14982,7 +14982,7 @@ fn test_containers_single_field_test_struct_random_chaos_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0800000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -14990,7 +14990,7 @@ fn test_containers_single_field_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_3() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -15004,7 +15004,7 @@ fn test_containers_fixed_test_struct_max_3() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -15012,7 +15012,7 @@ fn test_containers_fixed_test_struct_max_3() {
 
 #[test]
 fn test_containers_var_test_struct_nil_6() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 15781,
         b: List::<u16, 1024>::from_iter([]),
         c: 117,
@@ -15026,7 +15026,7 @@ fn test_containers_var_test_struct_nil_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7cee3918d516db214447c2cbbe0d0ddb54dd8f75652bfc15ec6abcf3363f8380");
     assert_eq!(root, expected_root);
@@ -15034,7 +15034,7 @@ fn test_containers_var_test_struct_nil_6() {
 
 #[test]
 fn test_containers_bits_struct_max_8() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -15050,7 +15050,7 @@ fn test_containers_bits_struct_max_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f369e7425a52cffdac341543d5368d4f233d155a29c2d0bfece3c159c0c6d120");
     assert_eq!(root, expected_root);
@@ -15058,7 +15058,7 @@ fn test_containers_bits_struct_max_8() {
 
 #[test]
 fn test_containers_var_test_struct_random_chaos_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 20024,
         b: List::<u16, 1024>::from_iter([
             50415, 14691, 1540, 5555, 46426, 5084, 61089, 64926, 6761, 37513, 65376, 54489, 38631,
@@ -15149,7 +15149,7 @@ fn test_containers_var_test_struct_random_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("686b4990347887370f9ad5116ce942ea8bb7f752a959fcee547af5655075a358");
     assert_eq!(root, expected_root);
@@ -15157,7 +15157,7 @@ fn test_containers_var_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_one_5() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -15173,7 +15173,7 @@ fn test_containers_bits_struct_one_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0a9f6477919000daaadaaf9f290347d1e51387c7bc8843bc8188c5ec65323b1b");
     assert_eq!(root, expected_root);
@@ -15181,7 +15181,7 @@ fn test_containers_bits_struct_one_5() {
 
 #[test]
 fn test_containers_var_test_struct_nil_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 57718,
         b: List::<u16, 1024>::from_iter([]),
         c: 30,
@@ -15195,7 +15195,7 @@ fn test_containers_var_test_struct_nil_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0816604b74ffed4de14e90ab139ee0242dab266445b8e932ebc2379a38059f9b");
     assert_eq!(root, expected_root);
@@ -15203,7 +15203,7 @@ fn test_containers_var_test_struct_nil_1() {
 
 #[test]
 fn test_containers_bits_struct_one_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -15219,7 +15219,7 @@ fn test_containers_bits_struct_one_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b7b8ea390463d99872628ca0d4aa1fc58abe086fd2b51b37396c61388d044ebe");
     assert_eq!(root, expected_root);
@@ -15227,7 +15227,7 @@ fn test_containers_bits_struct_one_2() {
 
 #[test]
 fn test_containers_complex_test_struct_random_chaos_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 11713,
         b: List::<u16, 128>::from_iter([
             38091, 53824, 7944, 31766, 19699, 31242, 4608, 29028, 11885, 840, 21861, 65003, 18717,
@@ -15441,7 +15441,7 @@ fn test_containers_complex_test_struct_random_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("24e69161141c575a7830d20b60f6fea329b6111bcff7cf03437f1f533057722e");
     assert_eq!(root, expected_root);
@@ -15449,7 +15449,7 @@ fn test_containers_complex_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_random_3() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 32772,
         b: List::<u16, 128>::from_iter([
             46512, 38507, 19398, 17365, 6742, 22022, 38263, 43803, 45345, 15434, 50542, 53308,
@@ -15688,7 +15688,7 @@ fn test_containers_complex_test_struct_random_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("94ae9da9095ee46b7da1e78d09ff01ca80f996b586792b8a586858b479416fad");
     assert_eq!(root, expected_root);
@@ -15696,7 +15696,7 @@ fn test_containers_complex_test_struct_random_3() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_4() {
-    let value = SingleFieldTestStruct { a: 17 };
+    let mut value = SingleFieldTestStruct { a: 17 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_4/serialized.ssz_snappy",
@@ -15706,7 +15706,7 @@ fn test_containers_single_field_test_struct_random_4() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15714,7 +15714,7 @@ fn test_containers_single_field_test_struct_random_4() {
 
 #[test]
 fn test_containers_bits_struct_max_6() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -15730,7 +15730,7 @@ fn test_containers_bits_struct_max_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("42fa920fba341869972baf9a71aec699fee9f0d6797f18b5e1406989a2487d81");
     assert_eq!(root, expected_root);
@@ -15738,7 +15738,7 @@ fn test_containers_bits_struct_max_6() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_chaos_2() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 255,
         b: 18446744073709551615,
         c: 4294967295,
@@ -15752,7 +15752,7 @@ fn test_containers_fixed_test_struct_max_chaos_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -15760,7 +15760,7 @@ fn test_containers_fixed_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_var_test_struct_nil_8() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 45577,
         b: List::<u16, 1024>::from_iter([]),
         c: 105,
@@ -15774,7 +15774,7 @@ fn test_containers_var_test_struct_nil_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4862179b12978591ac35adb894ffc2ee201c33254090051f7c93f988c3335432");
     assert_eq!(root, expected_root);
@@ -15782,7 +15782,7 @@ fn test_containers_var_test_struct_nil_8() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_3() {
-    let value = SingleFieldTestStruct { a: 46 };
+    let mut value = SingleFieldTestStruct { a: 46 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_3/serialized.ssz_snappy",
@@ -15792,7 +15792,7 @@ fn test_containers_single_field_test_struct_random_3() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2e00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15800,7 +15800,7 @@ fn test_containers_single_field_test_struct_random_3() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_chaos_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 46450,
         b: List::<u16, 1024>::from_iter([
             53815, 23219, 41304, 45330, 32243, 36712, 34238, 37499, 13393, 61842, 46925, 51786,
@@ -15898,7 +15898,7 @@ fn test_containers_var_test_struct_lengthy_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("97fdc2293c9a8a24c32d19ef5284f9e7a767d37b64f50eaaf49e75da4e1b8b23");
     assert_eq!(root, expected_root);
@@ -15906,7 +15906,7 @@ fn test_containers_var_test_struct_lengthy_chaos_1() {
 
 #[test]
 fn test_containers_small_test_struct_random_chaos_2() {
-    let value = SmallTestStruct { a: 9252, b: 757 };
+    let mut value = SmallTestStruct { a: 9252, b: 757 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_chaos_2/serialized.ssz_snappy",
@@ -15916,7 +15916,7 @@ fn test_containers_small_test_struct_random_chaos_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("d17fddce0872a0df611122a19c13d74e66fbebb51ec5165c03243331a09f157d");
     assert_eq!(root, expected_root);
@@ -15924,7 +15924,7 @@ fn test_containers_small_test_struct_random_chaos_2() {
 
 #[test]
 fn test_containers_complex_test_struct_random_4() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 56777,
         b: List::<u16, 128>::from_iter([
             58669, 14901, 4758, 38656, 35668, 56803, 11682, 18310, 55525, 27960, 27146, 38815,
@@ -16044,7 +16044,7 @@ fn test_containers_complex_test_struct_random_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f4d8e28604d4d5c60dcb52d5f1397f0016cdcbacab21e3e87f943fbf548c0e2a");
     assert_eq!(root, expected_root);
@@ -16052,7 +16052,7 @@ fn test_containers_complex_test_struct_random_4() {
 
 #[test]
 fn test_containers_bits_struct_max_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -16068,7 +16068,7 @@ fn test_containers_bits_struct_max_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a7b7b02a9e2d2899c443fa4da11dedecc7b1b1c76f90e8c1a7cc4b0830e84336");
     assert_eq!(root, expected_root);
@@ -16076,7 +16076,7 @@ fn test_containers_bits_struct_max_1() {
 
 #[test]
 fn test_containers_var_test_struct_zero_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -16116,7 +16116,7 @@ fn test_containers_var_test_struct_zero_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("00d6017fcaf6ea8e4d6c6d6ab21149d938ab96ae3452ca5ab88eb553a71b9075");
     assert_eq!(root, expected_root);
@@ -16124,7 +16124,7 @@ fn test_containers_var_test_struct_zero_1() {
 
 #[test]
 fn test_containers_small_test_struct_max_4() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_4/serialized.ssz_snappy",
@@ -16134,7 +16134,7 @@ fn test_containers_small_test_struct_max_4() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -16142,7 +16142,7 @@ fn test_containers_small_test_struct_max_4() {
 
 #[test]
 fn test_containers_bits_struct_zero_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -16158,7 +16158,7 @@ fn test_containers_bits_struct_zero_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("93d1e2d05c32e35744a9c04b1f81f2f8c58a491a747893d1b6b9d26ade98b9b9");
     assert_eq!(root, expected_root);
@@ -16166,7 +16166,7 @@ fn test_containers_bits_struct_zero_1() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_chaos_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -16265,7 +16265,7 @@ fn test_containers_complex_test_struct_zero_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4bad3b50403828f333928bf4d286a44e7852ffa5ac91a099da5c73fb57c2c3e6");
     assert_eq!(root, expected_root);
@@ -16273,7 +16273,7 @@ fn test_containers_complex_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_small_test_struct_max_3() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_3/serialized.ssz_snappy",
@@ -16283,7 +16283,7 @@ fn test_containers_small_test_struct_max_3() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -16291,7 +16291,7 @@ fn test_containers_small_test_struct_max_3() {
 
 #[test]
 fn test_containers_var_test_struct_zero_6() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -16331,7 +16331,7 @@ fn test_containers_var_test_struct_zero_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3c372594973b1e993a874e3a1fab6960e517050b60fbeab2baa0dc4cfeba15fe");
     assert_eq!(root, expected_root);
@@ -16339,7 +16339,7 @@ fn test_containers_var_test_struct_zero_6() {
 
 #[test]
 fn test_containers_bits_struct_zero_6() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -16355,7 +16355,7 @@ fn test_containers_bits_struct_zero_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7aa68d25017352ef95142af2bb269ce805269676da6111d74887aa9cdcb072a4");
     assert_eq!(root, expected_root);
@@ -16363,7 +16363,7 @@ fn test_containers_bits_struct_zero_6() {
 
 #[test]
 fn test_containers_var_test_struct_random_4() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 48280,
         b: List::<u16, 1024>::from_iter([
             13530, 41391, 39881, 12308, 13381, 11905, 39267, 629, 332, 41821, 9742, 10462, 15406,
@@ -16445,7 +16445,7 @@ fn test_containers_var_test_struct_random_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9e6297181610b6c462e663ecc29780c2367606e522a083d75811b5b8dd68b155");
     assert_eq!(root, expected_root);
@@ -16453,7 +16453,7 @@ fn test_containers_var_test_struct_random_4() {
 
 #[test]
 fn test_containers_bits_struct_nil_chaos_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -16469,7 +16469,7 @@ fn test_containers_bits_struct_nil_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b5d2c977cf885fab0f2bcac642caa687fe989b39577ef8ce73f90458daadb1e4");
     assert_eq!(root, expected_root);
@@ -16477,7 +16477,7 @@ fn test_containers_bits_struct_nil_chaos_2() {
 
 #[test]
 fn test_containers_complex_test_struct_zero() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -16564,7 +16564,7 @@ fn test_containers_complex_test_struct_zero() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2ec3c08dd3340ae02ef2cfc18752d3d87b74b2627a1b89296e8308db83a10d76");
     assert_eq!(root, expected_root);
@@ -16572,7 +16572,7 @@ fn test_containers_complex_test_struct_zero() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_4() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, false, false, false]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -16588,7 +16588,7 @@ fn test_containers_bits_struct_lengthy_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9fef37c569b75fd6c8128910e47d0c566fdfef1b6e0559e80729e27bb43a9593");
     assert_eq!(root, expected_root);
@@ -16596,7 +16596,7 @@ fn test_containers_bits_struct_lengthy_4() {
 
 #[test]
 fn test_containers_bits_struct_zero_8() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -16612,7 +16612,7 @@ fn test_containers_bits_struct_zero_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("24126453e1d5be00e010b8e9ca4f512d777db14429656f9dfb360683b114f36d");
     assert_eq!(root, expected_root);
@@ -16620,7 +16620,7 @@ fn test_containers_bits_struct_zero_8() {
 
 #[test]
 fn test_containers_var_test_struct_random_3() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 36707,
         b: List::<u16, 1024>::from_iter([
             12654, 3873, 25427, 28554, 12347, 17269, 55449, 54337, 28007, 48659, 45648, 53594,
@@ -16673,7 +16673,7 @@ fn test_containers_var_test_struct_random_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1a6dd659e4613869e40aaf157b34202984ed415d8e1a840e77fdca8131eee28d");
     assert_eq!(root, expected_root);
@@ -16681,7 +16681,7 @@ fn test_containers_var_test_struct_random_3() {
 
 #[test]
 fn test_containers_var_test_struct_one_chaos_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 6367,
         b: List::<u16, 1024>::from_iter([33756]),
         c: 52,
@@ -16695,7 +16695,7 @@ fn test_containers_var_test_struct_one_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("241b66eb58b52471a5db434909765ffe1c393b77460c72417926a78964477772");
     assert_eq!(root, expected_root);
@@ -16703,7 +16703,7 @@ fn test_containers_var_test_struct_one_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_3() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, false, false, false, true]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -16719,7 +16719,7 @@ fn test_containers_bits_struct_lengthy_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6ed9d1f323c1b7c84169e063e266ad39f60b7fb4162e77d91aa7635a289b9413");
     assert_eq!(root, expected_root);
@@ -16727,7 +16727,7 @@ fn test_containers_bits_struct_lengthy_3() {
 
 #[test]
 fn test_containers_var_test_struct_zero_8() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -16773,7 +16773,7 @@ fn test_containers_var_test_struct_zero_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9c0af32d7d42da4c4cf3141012d144cc47fff337f7a6d8dbcc8ea41b9166c856");
     assert_eq!(root, expected_root);
@@ -16781,7 +16781,7 @@ fn test_containers_var_test_struct_zero_8() {
 
 #[test]
 fn test_containers_complex_test_struct_random_5() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 55035,
         b: List::<u16, 128>::from_iter([
             29868, 51881, 52866, 49329, 55132, 5639, 4474, 38677, 12583, 40315, 8217, 62286, 38849,
@@ -17012,7 +17012,7 @@ fn test_containers_complex_test_struct_random_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4f1b6daa8389ed6595cc6d1ff4ec323cbefa31bdde591a80b797afcb336f2ecc");
     assert_eq!(root, expected_root);
@@ -17020,7 +17020,7 @@ fn test_containers_complex_test_struct_random_5() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_chaos_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 37078,
         b: List::<u16, 1024>::from_iter([
             47932, 15562, 49816, 7730, 8297, 2042, 10168, 28087, 38758, 5767, 45908, 9696, 22529,
@@ -17118,7 +17118,7 @@ fn test_containers_var_test_struct_lengthy_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1cfc5952deb977ccf63665ea49c30474662e9c681cd7070973ef91616f984d2e");
     assert_eq!(root, expected_root);
@@ -17126,7 +17126,7 @@ fn test_containers_var_test_struct_lengthy_chaos_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_2() {
-    let value = SingleFieldTestStruct { a: 3 };
+    let mut value = SingleFieldTestStruct { a: 3 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_2/serialized.ssz_snappy",
@@ -17136,7 +17136,7 @@ fn test_containers_single_field_test_struct_random_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17144,7 +17144,7 @@ fn test_containers_single_field_test_struct_random_2() {
 
 #[test]
 fn test_containers_bits_struct_max_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -17160,7 +17160,7 @@ fn test_containers_bits_struct_max_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ad8ac96de2066eef5bcb859e32dbf4120dff7d64efd015629878c805d7d38a01");
     assert_eq!(root, expected_root);
@@ -17168,7 +17168,7 @@ fn test_containers_bits_struct_max_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_5() {
-    let value = SingleFieldTestStruct { a: 42 };
+    let mut value = SingleFieldTestStruct { a: 42 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_random_5/serialized.ssz_snappy",
@@ -17178,7 +17178,7 @@ fn test_containers_single_field_test_struct_random_5() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2a00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -17186,7 +17186,7 @@ fn test_containers_single_field_test_struct_random_5() {
 
 #[test]
 fn test_containers_complex_test_struct_random_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 28502,
         b: List::<u16, 128>::from_iter([
             54777, 54608, 59283, 47559, 63981, 34242, 54234, 15282, 42195, 40500, 46251, 44616,
@@ -17421,7 +17421,7 @@ fn test_containers_complex_test_struct_random_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0a431553e8b2485b7700822b68918f62cbd943d6c8f4413f962a0f7d811f3b02");
     assert_eq!(root, expected_root);
@@ -17429,7 +17429,7 @@ fn test_containers_complex_test_struct_random_2() {
 
 #[test]
 fn test_containers_bits_struct_max_7() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -17445,7 +17445,7 @@ fn test_containers_bits_struct_max_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("679f5c980c00f2253a3bdd1844e3a97fb1ea2d37916e8defd25253875ad27478");
     assert_eq!(root, expected_root);
@@ -17453,7 +17453,7 @@ fn test_containers_bits_struct_max_7() {
 
 #[test]
 fn test_containers_var_test_struct_nil_9() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 26413,
         b: List::<u16, 1024>::from_iter([]),
         c: 229,
@@ -17467,7 +17467,7 @@ fn test_containers_var_test_struct_nil_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7cb7293235a467c2292090388636eeadcfd089f600b5ae046ac7fca0dff276d4");
     assert_eq!(root, expected_root);
@@ -17475,7 +17475,7 @@ fn test_containers_var_test_struct_nil_9() {
 
 #[test]
 fn test_containers_var_test_struct_nil_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 19247,
         b: List::<u16, 1024>::from_iter([]),
         c: 218,
@@ -17489,7 +17489,7 @@ fn test_containers_var_test_struct_nil_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("222aecf4aec9d26c1185796b4569be800bab5a97460e4cb81c357d8a5b108082");
     assert_eq!(root, expected_root);
@@ -17497,7 +17497,7 @@ fn test_containers_var_test_struct_nil_0() {
 
 #[test]
 fn test_containers_complex_test_struct_random_chaos_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65478,
         b: List::<u16, 128>::from_iter([13600, 42076]),
         c: 93,
@@ -17663,7 +17663,7 @@ fn test_containers_complex_test_struct_random_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("72d82a631e33acaf1200ebef7e3a20557fede419a3326141a04fed1652c77e7d");
     assert_eq!(root, expected_root);
@@ -17671,7 +17671,7 @@ fn test_containers_complex_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_one_3() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -17687,7 +17687,7 @@ fn test_containers_bits_struct_one_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f5a1b1469addca4b542972bcd8c609a6eea1253ee3152b9d816d77bad37d3a07");
     assert_eq!(root, expected_root);
@@ -17695,7 +17695,7 @@ fn test_containers_bits_struct_one_3() {
 
 #[test]
 fn test_containers_var_test_struct_nil_7() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 64459,
         b: List::<u16, 1024>::from_iter([]),
         c: 222,
@@ -17709,7 +17709,7 @@ fn test_containers_var_test_struct_nil_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("12a034ffc15a1416af36a2042cea64289a7a587e6f0fe97b3c66feaec47e0fc0");
     assert_eq!(root, expected_root);
@@ -17717,7 +17717,7 @@ fn test_containers_var_test_struct_nil_7() {
 
 #[test]
 fn test_containers_bits_struct_max_9() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, true, true, true]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -17733,7 +17733,7 @@ fn test_containers_bits_struct_max_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a6a9c5f7ac748508e6ca448b1c79a3ce3287ce4d84e54bb4d0ea912963cc1ac9");
     assert_eq!(root, expected_root);
@@ -17741,7 +17741,7 @@ fn test_containers_bits_struct_max_9() {
 
 #[test]
 fn test_containers_bits_struct_one_4() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -17757,7 +17757,7 @@ fn test_containers_bits_struct_one_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56c00424e17ba0839c67e441de93d1a233518a787b9f5beae8f9a7800f7721d2");
     assert_eq!(root, expected_root);
@@ -17765,7 +17765,7 @@ fn test_containers_bits_struct_one_4() {
 
 #[test]
 fn test_containers_var_test_struct_random_chaos_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 62039,
         b: List::<u16, 1024>::from_iter([
             23305, 29806, 56403, 51159, 2516, 49207, 25302, 92, 55514, 1548, 27014, 11520, 30196,
@@ -17795,7 +17795,7 @@ fn test_containers_var_test_struct_random_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7212d68f58c159cfebacb824dd52394ae2e2817dd1eae1f3249c5dfadc88fa35");
     assert_eq!(root, expected_root);
@@ -17803,7 +17803,7 @@ fn test_containers_var_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_one_chaos_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 28881,
         b: List::<u16, 1024>::from_iter([18944]),
         c: 105,
@@ -17817,7 +17817,7 @@ fn test_containers_var_test_struct_one_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("52e834b323f4651d8f7e8759ba002d7bb346289a1fb31be29a559b6a43318a61");
     assert_eq!(root, expected_root);
@@ -17825,7 +17825,7 @@ fn test_containers_var_test_struct_one_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_random_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 27676,
         b: List::<u16, 1024>::from_iter([
             44695, 48600, 31136, 19500, 44205, 36060, 25786, 26618, 37361, 8899, 64311, 2514, 9554,
@@ -17886,7 +17886,7 @@ fn test_containers_var_test_struct_random_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("bc5a1310b55ca40643862bd6365dce9d41bf6f167e67af00083bcfeafc305024");
     assert_eq!(root, expected_root);
@@ -17894,7 +17894,7 @@ fn test_containers_var_test_struct_random_2() {
 
 #[test]
 fn test_containers_bits_struct_zero_9() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -17910,7 +17910,7 @@ fn test_containers_bits_struct_zero_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("27b61f43e35013d439d4d131de8ad79811792cf58724d87ae45f1f3d1f74bacd");
     assert_eq!(root, expected_root);
@@ -17918,7 +17918,7 @@ fn test_containers_bits_struct_zero_9() {
 
 #[test]
 fn test_containers_small_test_struct_max() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max/serialized.ssz_snappy",
@@ -17928,7 +17928,7 @@ fn test_containers_small_test_struct_max() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -17936,7 +17936,7 @@ fn test_containers_small_test_struct_max() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, true, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -17952,7 +17952,7 @@ fn test_containers_bits_struct_lengthy_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("469f6b49a4ed8f733d42ee4e769eba9c19d5e07aff60b3f9486e30c95d919c95");
     assert_eq!(root, expected_root);
@@ -17960,7 +17960,7 @@ fn test_containers_bits_struct_lengthy_2() {
 
 #[test]
 fn test_containers_var_test_struct_zero_9() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -17984,7 +17984,7 @@ fn test_containers_var_test_struct_zero_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("bb7ea01c4c68bbaf1df07124552e34c661e2bd157ca71b6529c92f5feea448a2");
     assert_eq!(root, expected_root);
@@ -17992,7 +17992,7 @@ fn test_containers_var_test_struct_zero_9() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero/serialized.ssz_snappy",
@@ -18002,7 +18002,7 @@ fn test_containers_single_field_test_struct_zero() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -18010,7 +18010,7 @@ fn test_containers_single_field_test_struct_zero() {
 
 #[test]
 fn test_containers_var_test_struct_random_5() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 25799,
         b: List::<u16, 1024>::from_iter([
             31598, 4940, 7630, 36358, 26249, 12856, 15530, 61074, 54691, 56853, 51121, 21914,
@@ -18040,7 +18040,7 @@ fn test_containers_var_test_struct_random_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f7fba8efac43ce0600fe8e072e363cff8dff998913af976106b02c83de1c70c8");
     assert_eq!(root, expected_root);
@@ -18048,7 +18048,7 @@ fn test_containers_var_test_struct_random_5() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_5() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, false, true, false]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -18064,7 +18064,7 @@ fn test_containers_bits_struct_lengthy_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e855d6c5c37e013075aa63d9adc7887a1eba417b39695c4fd36ae276b78182a8");
     assert_eq!(root, expected_root);
@@ -18072,7 +18072,7 @@ fn test_containers_bits_struct_lengthy_5() {
 
 #[test]
 fn test_containers_var_test_struct_zero_7() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -18099,7 +18099,7 @@ fn test_containers_var_test_struct_zero_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ee2e89616ef26de2d2dd166f7b5aaa1c7f75cf467cb94cb2e578e41d5c4922a0");
     assert_eq!(root, expected_root);
@@ -18107,7 +18107,7 @@ fn test_containers_var_test_struct_zero_7() {
 
 #[test]
 fn test_containers_small_test_struct_max_2() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_2/serialized.ssz_snappy",
@@ -18117,7 +18117,7 @@ fn test_containers_small_test_struct_max_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -18125,7 +18125,7 @@ fn test_containers_small_test_struct_max_2() {
 
 #[test]
 fn test_containers_bits_struct_zero_7() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, false, false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -18141,7 +18141,7 @@ fn test_containers_bits_struct_zero_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7a14e144cf89605fa98f03d5315652596c9607d815e162b2d371d7bad872012d");
     assert_eq!(root, expected_root);
@@ -18149,7 +18149,7 @@ fn test_containers_bits_struct_zero_7() {
 
 #[test]
 fn test_containers_small_test_struct_max_5() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_5/serialized.ssz_snappy",
@@ -18159,7 +18159,7 @@ fn test_containers_small_test_struct_max_5() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -18167,7 +18167,7 @@ fn test_containers_small_test_struct_max_5() {
 
 #[test]
 fn test_containers_var_test_struct_zero_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -18201,7 +18201,7 @@ fn test_containers_var_test_struct_zero_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ec783aab2c6fdf1e39982bb3cb77c0ec5fe4d587519d26a1554bd129c1bff962");
     assert_eq!(root, expected_root);
@@ -18209,7 +18209,7 @@ fn test_containers_var_test_struct_zero_0() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_chaos_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -18310,7 +18310,7 @@ fn test_containers_complex_test_struct_zero_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("7234feb3b046a7cb785b398a7145a7dffd8e03e18ad7106a8b7b2c44d81f7e07");
     assert_eq!(root, expected_root);
@@ -18318,7 +18318,7 @@ fn test_containers_complex_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_zero_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false]),
         b: Bitvector::<2>::from_iter([false, false]),
         c: Bitvector::<1>::from_iter([false]),
@@ -18334,7 +18334,7 @@ fn test_containers_bits_struct_zero_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f8deab9880644342f558abbfafbbdcea80f0652e260bd8f6c14fdc18b5599426");
     assert_eq!(root, expected_root);
@@ -18342,7 +18342,7 @@ fn test_containers_bits_struct_zero_0() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_5() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65280,
         b: List::<u16, 128>::from_iter([
             33087, 53979, 31524, 62080, 24710, 39184, 59428, 4696, 65450, 13150, 6095, 62651,
@@ -18696,7 +18696,7 @@ fn test_containers_complex_test_struct_lengthy_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("71f26676fcb2b61cf22eaea122ab77a053ed19309f5af3ba56dc94d33c540b55");
     assert_eq!(root, expected_root);
@@ -18704,7 +18704,7 @@ fn test_containers_complex_test_struct_lengthy_5() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_0() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 170,
         b: 13097433917148758497,
         c: 2823316065,
@@ -18718,7 +18718,7 @@ fn test_containers_fixed_test_struct_random_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2b7d29235dcbef1517899cd47118beea7d81b46244cff605724676cd50f898ec");
     assert_eq!(root, expected_root);
@@ -18726,7 +18726,7 @@ fn test_containers_fixed_test_struct_random_0() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_2() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 19676,
         b: List::<u16, 128>::from_iter([
             26413, 56542, 62484, 27880, 9216, 53288, 53725, 51556, 51435, 17912, 31404, 48683,
@@ -19081,7 +19081,7 @@ fn test_containers_complex_test_struct_lengthy_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6501992f62e45a55d9706c46698a41647b690812cdc16dab6221b616df056030");
     assert_eq!(root, expected_root);
@@ -19089,7 +19089,7 @@ fn test_containers_complex_test_struct_lengthy_2() {
 
 #[test]
 fn test_containers_small_test_struct_random_8() {
-    let value = SmallTestStruct { a: 39639, b: 63050 };
+    let mut value = SmallTestStruct { a: 39639, b: 63050 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_8/serialized.ssz_snappy",
@@ -19099,7 +19099,7 @@ fn test_containers_small_test_struct_random_8() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("079c669a7e6f0122945cf099c09057ec21e3607ca1cb694c57796452606b7f22");
     assert_eq!(root, expected_root);
@@ -19107,7 +19107,7 @@ fn test_containers_small_test_struct_random_8() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_7() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 223,
         b: 8950381518244519629,
         c: 2819180549,
@@ -19121,7 +19121,7 @@ fn test_containers_fixed_test_struct_random_7() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1a20d6debe4b913fbf4c1cefbf34aaf46aada5bad445b9307aa917038c39b5a7");
     assert_eq!(root, expected_root);
@@ -19129,7 +19129,7 @@ fn test_containers_fixed_test_struct_random_7() {
 
 #[test]
 fn test_containers_small_test_struct_random_1() {
-    let value = SmallTestStruct { a: 19471, b: 11965 };
+    let mut value = SmallTestStruct { a: 19471, b: 11965 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_1/serialized.ssz_snappy",
@@ -19139,7 +19139,7 @@ fn test_containers_small_test_struct_random_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5c272251ea4047c6b2c442b3817841ce45aa71d79407b6b4716e29efef97bc2b");
     assert_eq!(root, expected_root);
@@ -19147,7 +19147,7 @@ fn test_containers_small_test_struct_random_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_9() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 202,
         b: 14820154409811446657,
         c: 3563199940,
@@ -19161,7 +19161,7 @@ fn test_containers_fixed_test_struct_random_9() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9ef2a1d5cbdac64f575b862be56da89ee7040a7ba55a689d0f508ce1e7716531");
     assert_eq!(root, expected_root);
@@ -19169,7 +19169,7 @@ fn test_containers_fixed_test_struct_random_9() {
 
 #[test]
 fn test_containers_small_test_struct_random_6() {
-    let value = SmallTestStruct { a: 11656, b: 6024 };
+    let mut value = SmallTestStruct { a: 11656, b: 6024 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_6/serialized.ssz_snappy",
@@ -19179,7 +19179,7 @@ fn test_containers_small_test_struct_random_6() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f9927c147e6280338f2b5c9c43bc70b4c6f2b1acd9d9ccba393147827075c24c");
     assert_eq!(root, expected_root);
@@ -19187,7 +19187,7 @@ fn test_containers_small_test_struct_random_6() {
 
 #[test]
 fn test_containers_bits_struct_nil_9() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -19203,7 +19203,7 @@ fn test_containers_bits_struct_nil_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5f0c9f6aea78a6c52c3cea1594d184237a74cfd7981c4d88206df4e0c5514942");
     assert_eq!(root, expected_root);
@@ -19211,7 +19211,7 @@ fn test_containers_bits_struct_nil_9() {
 
 #[test]
 fn test_containers_var_test_struct_max_7() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -19263,7 +19263,7 @@ fn test_containers_var_test_struct_max_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("79c96ac0d0f8a0b50c1f9b3387d304545f8748957f25169bd4312784818e5353");
     assert_eq!(root, expected_root);
@@ -19271,7 +19271,7 @@ fn test_containers_var_test_struct_max_7() {
 
 #[test]
 fn test_containers_complex_test_struct_max_chaos_0() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535]),
         c: 255,
@@ -19530,7 +19530,7 @@ fn test_containers_complex_test_struct_max_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1bfc71829055edccc1da5e34d4fd7a58a849e343be7cc6734311c62d841e19b8");
     assert_eq!(root, expected_root);
@@ -19538,7 +19538,7 @@ fn test_containers_complex_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_chaos_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([false, true, true, false, true]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -19554,7 +19554,7 @@ fn test_containers_bits_struct_lengthy_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b73c9629e7f6c711c93f623c20ae2887b6cdb264f1e89a62516a4da6954611cb");
     assert_eq!(root, expected_root);
@@ -19562,7 +19562,7 @@ fn test_containers_bits_struct_lengthy_chaos_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_2() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_2/serialized.ssz_snappy",
@@ -19572,7 +19572,7 @@ fn test_containers_fixed_test_struct_zero_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -19580,7 +19580,7 @@ fn test_containers_fixed_test_struct_zero_2() {
 
 #[test]
 fn test_containers_var_test_struct_max_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -19654,7 +19654,7 @@ fn test_containers_var_test_struct_max_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("91158cf42f7e55a15dc111ce85b67225bb2e07042fb0a85b43b12f1b734c9bb9");
     assert_eq!(root, expected_root);
@@ -19662,7 +19662,7 @@ fn test_containers_var_test_struct_max_0() {
 
 #[test]
 fn test_containers_var_test_struct_nil_chaos_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 35832,
         b: List::<u16, 1024>::from_iter([]),
         c: 217,
@@ -19676,7 +19676,7 @@ fn test_containers_var_test_struct_nil_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("efee06dc27b3f364ac899b45bb1d3e1612a7516d0254907aad6e7320301d5e42");
     assert_eq!(root, expected_root);
@@ -19684,7 +19684,7 @@ fn test_containers_var_test_struct_nil_chaos_1() {
 
 #[test]
 fn test_containers_small_test_struct_max_chaos_0() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_chaos_0/serialized.ssz_snappy",
@@ -19694,7 +19694,7 @@ fn test_containers_small_test_struct_max_chaos_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -19702,7 +19702,7 @@ fn test_containers_small_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_8() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 12486,
         b: List::<u16, 1024>::from_iter([
             3523, 47093, 8760, 16683, 5622, 11376, 60724, 43644, 23036, 46199, 9602, 35494, 33105,
@@ -19801,7 +19801,7 @@ fn test_containers_var_test_struct_lengthy_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("961192fbfbb60058c5e4d339d23f123b1765d795e35241da12e2a85b3dbdda63");
     assert_eq!(root, expected_root);
@@ -19809,7 +19809,7 @@ fn test_containers_var_test_struct_lengthy_8() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_5() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_5/serialized.ssz_snappy",
@@ -19819,7 +19819,7 @@ fn test_containers_fixed_test_struct_zero_5() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -19827,7 +19827,7 @@ fn test_containers_fixed_test_struct_zero_5() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 21335,
         b: List::<u16, 1024>::from_iter([
             53687, 9781, 37580, 36287, 56492, 62426, 6786, 16575, 14820, 21314, 43, 42803, 61037,
@@ -19925,7 +19925,7 @@ fn test_containers_var_test_struct_lengthy_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("688b42fd81bb47e8b620bbb092900829af130bb53066e62f604b995e496b2a4a");
     assert_eq!(root, expected_root);
@@ -19933,7 +19933,7 @@ fn test_containers_var_test_struct_lengthy_1() {
 
 #[test]
 fn test_containers_var_test_struct_one_4() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 20579,
         b: List::<u16, 1024>::from_iter([59691]),
         c: 90,
@@ -19947,7 +19947,7 @@ fn test_containers_var_test_struct_one_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("16d1dd07880a83d46fc95fb94041bf333448534aa37fdd530977f57ad5031a36");
     assert_eq!(root, expected_root);
@@ -19955,7 +19955,7 @@ fn test_containers_var_test_struct_one_4() {
 
 #[test]
 fn test_containers_var_test_struct_max_9() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -19997,7 +19997,7 @@ fn test_containers_var_test_struct_max_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("56000973efb39fe164fbb325218a9cf3d0dcfdf1f50b1f7fefb20efaa1bdcbc4");
     assert_eq!(root, expected_root);
@@ -20005,7 +20005,7 @@ fn test_containers_var_test_struct_max_9() {
 
 #[test]
 fn test_containers_bits_struct_nil_7() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -20021,7 +20021,7 @@ fn test_containers_bits_struct_nil_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("cf8f07d7ff9ded4a52803bab9c5d38f91808b1072da9d1c81aabaeb57c12f29f");
     assert_eq!(root, expected_root);
@@ -20029,7 +20029,7 @@ fn test_containers_bits_struct_nil_7() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_chaos_0() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_chaos_0/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -20037,7 +20037,7 @@ fn test_containers_single_field_test_struct_zero_chaos_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -20045,7 +20045,7 @@ fn test_containers_single_field_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_one_3() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 22598,
         b: List::<u16, 1024>::from_iter([37706]),
         c: 49,
@@ -20059,7 +20059,7 @@ fn test_containers_var_test_struct_one_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1d73b6e1e6844e9b714e1b26959086d3dca0930f070971569b2d0ab6d6c5bf95");
     assert_eq!(root, expected_root);
@@ -20067,7 +20067,7 @@ fn test_containers_var_test_struct_one_3() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_6() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 64971,
         b: List::<u16, 1024>::from_iter([
             40774, 45065, 65170, 5097, 16471, 56033, 19897, 27009, 55421, 7846, 18876, 49670,
@@ -20165,7 +20165,7 @@ fn test_containers_var_test_struct_lengthy_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1b1286cbc2cedeb2013dbb49743dccf46f4b831a1b6d0dd6ccfd996f53c580dd");
     assert_eq!(root, expected_root);
@@ -20173,7 +20173,7 @@ fn test_containers_var_test_struct_lengthy_6() {
 
 #[test]
 fn test_containers_bits_struct_nil_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -20189,7 +20189,7 @@ fn test_containers_bits_struct_nil_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("34d6ec1518de55f431f8d344f0687350c926f34d803c2a5f9c6343677f954061");
     assert_eq!(root, expected_root);
@@ -20197,7 +20197,7 @@ fn test_containers_bits_struct_nil_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_8() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 98,
         b: 13284016551454210865,
         c: 303971524,
@@ -20211,7 +20211,7 @@ fn test_containers_fixed_test_struct_random_8() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8e18f10531f714ba08f9d0a283ca65863d5ced520ce2ed2861cd7b261eee43ca");
     assert_eq!(root, expected_root);
@@ -20219,7 +20219,7 @@ fn test_containers_fixed_test_struct_random_8() {
 
 #[test]
 fn test_containers_small_test_struct_random_7() {
-    let value = SmallTestStruct { a: 35335, b: 8267 };
+    let mut value = SmallTestStruct { a: 35335, b: 8267 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_7/serialized.ssz_snappy",
@@ -20229,7 +20229,7 @@ fn test_containers_small_test_struct_random_7() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a9ea01512c31f35e35201b0d1f69c109a6e985c9672c055b8160436a1647b36c");
     assert_eq!(root, expected_root);
@@ -20237,7 +20237,7 @@ fn test_containers_small_test_struct_random_7() {
 
 #[test]
 fn test_containers_small_test_struct_random_0() {
-    let value = SmallTestStruct { a: 63471, b: 60758 };
+    let mut value = SmallTestStruct { a: 63471, b: 60758 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_0/serialized.ssz_snappy",
@@ -20247,7 +20247,7 @@ fn test_containers_small_test_struct_random_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("54b0b915e1cf6543b9af7f7a4e5122fa9f4fa50352eeab6f0c3b033610a4d54d");
     assert_eq!(root, expected_root);
@@ -20255,7 +20255,7 @@ fn test_containers_small_test_struct_random_0() {
 
 #[test]
 fn test_containers_small_test_struct_random_9() {
-    let value = SmallTestStruct { a: 46561, b: 34924 };
+    let mut value = SmallTestStruct { a: 46561, b: 34924 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_random_9/serialized.ssz_snappy",
@@ -20265,7 +20265,7 @@ fn test_containers_small_test_struct_random_9() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("222ce608a4c1abcbdfcf6db2f2927df6a0ad782eb9dfc586236897d304e20b03");
     assert_eq!(root, expected_root);
@@ -20273,7 +20273,7 @@ fn test_containers_small_test_struct_random_9() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_3() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 18529,
         b: List::<u16, 128>::from_iter([
             63901, 56928, 34026, 2156, 25223, 3105, 6521, 1554, 6929, 49447, 40332, 14581, 58068,
@@ -20627,7 +20627,7 @@ fn test_containers_complex_test_struct_lengthy_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5e58b695d0cbbdb4ad678f5786d4931228aab7d69bd3e78f752326ead3fb6360");
     assert_eq!(root, expected_root);
@@ -20635,7 +20635,7 @@ fn test_containers_complex_test_struct_lengthy_3() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_6() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 239,
         b: 5454313257518522816,
         c: 797239823,
@@ -20649,7 +20649,7 @@ fn test_containers_fixed_test_struct_random_6() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("121931c91bba4fa691f1bcc82c561e65ecd0eb6441fa7960ecaee65bcd0149f7");
     assert_eq!(root, expected_root);
@@ -20657,7 +20657,7 @@ fn test_containers_fixed_test_struct_random_6() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_4() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 48787,
         b: List::<u16, 128>::from_iter([
             63651, 25468, 28112, 2139, 52666, 19182, 3056, 17197, 52156, 19060, 32580, 13573,
@@ -21012,7 +21012,7 @@ fn test_containers_complex_test_struct_lengthy_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b05d615353d2d4e8a52506e147d553cc6056507b364280955ef2206abd5539be");
     assert_eq!(root, expected_root);
@@ -21020,7 +21020,7 @@ fn test_containers_complex_test_struct_lengthy_4() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_1() {
-    let value = FixedTestStruct {
+    let mut value = FixedTestStruct {
         a: 85,
         b: 3025325611966003710,
         c: 2393715144,
@@ -21034,7 +21034,7 @@ fn test_containers_fixed_test_struct_random_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("35f97f08051739f6cbd5b4e79e57b06ee7c7944d9aadcb72a3fd2221763ac7c4");
     assert_eq!(root, expected_root);
@@ -21042,7 +21042,7 @@ fn test_containers_fixed_test_struct_random_1() {
 
 #[test]
 fn test_containers_var_test_struct_one_2() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 31642,
         b: List::<u16, 1024>::from_iter([59815]),
         c: 220,
@@ -21056,7 +21056,7 @@ fn test_containers_var_test_struct_one_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c1bd1985036a67f5b0cc7b414fbbc46213020a1e0746b10389673c62f2048578");
     assert_eq!(root, expected_root);
@@ -21064,7 +21064,7 @@ fn test_containers_var_test_struct_one_2() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_7() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 41770,
         b: List::<u16, 1024>::from_iter([
             58939, 21346, 39284, 62459, 30183, 41116, 8063, 63486, 50992, 6541, 49668, 60143,
@@ -21162,7 +21162,7 @@ fn test_containers_var_test_struct_lengthy_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("060123a3d904a063f06fd68668b87b5cf3055b5dac360e394c82a93f77f59122");
     assert_eq!(root, expected_root);
@@ -21170,7 +21170,7 @@ fn test_containers_var_test_struct_lengthy_7() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_chaos_1() {
-    let value = SingleFieldTestStruct { a: 0 };
+    let mut value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz_rs/tests/data/containers/valid/SingleFieldTestStruct_zero_chaos_1/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -21178,7 +21178,7 @@ fn test_containers_single_field_test_struct_zero_chaos_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -21186,7 +21186,7 @@ fn test_containers_single_field_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_nil_1() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -21202,7 +21202,7 @@ fn test_containers_bits_struct_nil_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("09bc67e7267c47092b276f600b9d424af52f153ea649ec71934bde0d17a3c04a");
     assert_eq!(root, expected_root);
@@ -21210,7 +21210,7 @@ fn test_containers_bits_struct_nil_1() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 61133,
         b: List::<u16, 1024>::from_iter([
             44799, 46899, 35617, 2513, 17201, 21580, 57273, 28701, 30553, 35793, 59421, 11954,
@@ -21308,7 +21308,7 @@ fn test_containers_var_test_struct_lengthy_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("71e7aa654855c5f5f169d98f5d3d380eafade90bd2360881a10eaedc990d8c2d");
     assert_eq!(root, expected_root);
@@ -21316,7 +21316,7 @@ fn test_containers_var_test_struct_lengthy_0() {
 
 #[test]
 fn test_containers_var_test_struct_one_5() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 48023,
         b: List::<u16, 1024>::from_iter([8630]),
         c: 216,
@@ -21330,7 +21330,7 @@ fn test_containers_var_test_struct_one_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("c062dede49358629be70279a66e2aea28da2a7746336179838b35226557ad6f9");
     assert_eq!(root, expected_root);
@@ -21338,7 +21338,7 @@ fn test_containers_var_test_struct_one_5() {
 
 #[test]
 fn test_containers_var_test_struct_max_8() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -21409,7 +21409,7 @@ fn test_containers_var_test_struct_max_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f43b89ecb1afcea42daf293bdd44f386565d4798ab5dc989b91ccc5964714e36");
     assert_eq!(root, expected_root);
@@ -21417,7 +21417,7 @@ fn test_containers_var_test_struct_max_8() {
 
 #[test]
 fn test_containers_bits_struct_nil_6() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([true, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -21433,7 +21433,7 @@ fn test_containers_bits_struct_nil_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("66142f50cb9200a075d512910dd5614263dcb2a5060a3ff0d88f0127e29b3931");
     assert_eq!(root, expected_root);
@@ -21441,7 +21441,7 @@ fn test_containers_bits_struct_nil_6() {
 
 #[test]
 fn test_containers_complex_test_struct_max() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -21546,7 +21546,7 @@ fn test_containers_complex_test_struct_max() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("eb868df5a7f8bf87bdca38c2aa78f9c1322892196dd0abc441231ac34b3aebb0");
     assert_eq!(root, expected_root);
@@ -21554,7 +21554,7 @@ fn test_containers_complex_test_struct_max() {
 
 #[test]
 fn test_containers_var_test_struct_max_1() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -21640,7 +21640,7 @@ fn test_containers_var_test_struct_max_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("badeb02dc73020bf5c581d481c64ee98fd59e80cfa1827cf7046bd123607d5a1");
     assert_eq!(root, expected_root);
@@ -21648,7 +21648,7 @@ fn test_containers_var_test_struct_max_1() {
 
 #[test]
 fn test_containers_small_test_struct_max_chaos_1() {
-    let value = SmallTestStruct { a: 65535, b: 65535 };
+    let mut value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/SmallTestStruct_max_chaos_1/serialized.ssz_snappy",
@@ -21658,7 +21658,7 @@ fn test_containers_small_test_struct_max_chaos_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -21666,7 +21666,7 @@ fn test_containers_small_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_nil_chaos_0() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 4227,
         b: List::<u16, 1024>::from_iter([]),
         c: 44,
@@ -21680,7 +21680,7 @@ fn test_containers_var_test_struct_nil_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ba51affcafec76b1d7f201a539d7502dab39ea9db86436cd880bce8ebf174721");
     assert_eq!(root, expected_root);
@@ -21688,7 +21688,7 @@ fn test_containers_var_test_struct_nil_chaos_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_4() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_4/serialized.ssz_snappy",
@@ -21698,7 +21698,7 @@ fn test_containers_fixed_test_struct_zero_4() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -21706,7 +21706,7 @@ fn test_containers_fixed_test_struct_zero_4() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_9() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 2619,
         b: List::<u16, 1024>::from_iter([
             13129, 9486, 51703, 31906, 60795, 3512, 38232, 36482, 19605, 10895, 45636, 37364,
@@ -21804,7 +21804,7 @@ fn test_containers_var_test_struct_lengthy_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3e9b7ce7a3b6f7ea4879f0d033905f305f360580242ecddd245cd2b78b47a81b");
     assert_eq!(root, expected_root);
@@ -21812,7 +21812,7 @@ fn test_containers_var_test_struct_lengthy_9() {
 
 #[test]
 fn test_containers_complex_test_struct_max_chaos_1() {
-    let value = ComplexTestStruct {
+    let mut value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -22056,7 +22056,7 @@ fn test_containers_complex_test_struct_max_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("96cc111eeb992df1f47406ede8339868e8cd50281c7fdd553b742768a6ec8c1c");
     assert_eq!(root, expected_root);
@@ -22064,7 +22064,7 @@ fn test_containers_complex_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_chaos_0() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true, true, false, false, true]),
         b: Bitvector::<2>::from_iter([true, false]),
         c: Bitvector::<1>::from_iter([true]),
@@ -22080,7 +22080,7 @@ fn test_containers_bits_struct_lengthy_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("8615f5ce488e94a1a5b01d715a1931806ef7b5064acc413c6e3f30a16247effe");
     assert_eq!(root, expected_root);
@@ -22088,7 +22088,7 @@ fn test_containers_bits_struct_lengthy_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_nil_8() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([true]),
@@ -22104,7 +22104,7 @@ fn test_containers_bits_struct_nil_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0d85fba91fb9c52366820101ae72c082568ac76f8c5250ea9d2dabd5943dc298");
     assert_eq!(root, expected_root);
@@ -22112,7 +22112,7 @@ fn test_containers_bits_struct_nil_8() {
 
 #[test]
 fn test_containers_var_test_struct_max_6() {
-    let value = VarTestStruct {
+    let mut value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -22154,7 +22154,7 @@ fn test_containers_var_test_struct_max_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("294a1333b754020730798b3d264b4ab0ee45e799309caea42cd428bedcca46a6");
     assert_eq!(root, expected_root);
@@ -22162,7 +22162,7 @@ fn test_containers_var_test_struct_max_6() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_3() {
-    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/containers/valid/FixedTestStruct_zero_3/serialized.ssz_snappy",
@@ -22172,7 +22172,7 @@ fn test_containers_fixed_test_struct_zero_3() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -22180,7 +22180,7 @@ fn test_containers_fixed_test_struct_zero_3() {
 
 #[test]
 fn test_containers_bits_struct_one_chaos_2() {
-    let value = BitsStruct {
+    let mut value = BitsStruct {
         a: Bitlist::<5>::from_iter([true]),
         b: Bitvector::<2>::from_iter([false, true]),
         c: Bitvector::<1>::from_iter([false]),
@@ -22196,7 +22196,7 @@ fn test_containers_bits_struct_one_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("39f1b83c9006973db77b48722ae4dafdcfe92a60865c55d386d050dca10e365e");
     assert_eq!(root, expected_root);

--- a/ssz_rs/tests/test_utils.rs
+++ b/ssz_rs/tests/test_utils.rs
@@ -23,7 +23,7 @@ pub fn deserialize<T: SimpleSerialize>(encoding: &[u8]) -> T {
     ssz_rs::deserialize(encoding).expect("can deserialize")
 }
 
-pub fn hash_tree_root<T: SimpleSerialize>(value: &T) -> Node {
+pub fn hash_tree_root<T: SimpleSerialize>(value: &mut T) -> Node {
     let context = MerkleizationContext::new();
     value.hash_tree_root(&context).expect("can compute root")
 }

--- a/ssz_rs/tests/uints.rs
+++ b/ssz_rs/tests/uints.rs
@@ -7,7 +7,7 @@ use test_utils::{
 
 #[test]
 fn test_uints_uint_256_zero_2() {
-    let value = U256([
+    let mut value = U256([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ]);
@@ -20,7 +20,7 @@ fn test_uints_uint_256_zero_2() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -28,7 +28,7 @@ fn test_uints_uint_256_zero_2() {
 
 #[test]
 fn test_uints_uint_16_zero_3() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_zero_3/serialized.ssz_snappy",
@@ -38,7 +38,7 @@ fn test_uints_uint_16_zero_3() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -46,7 +46,7 @@ fn test_uints_uint_16_zero_3() {
 
 #[test]
 fn test_uints_uint_16_zero_4() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_zero_4/serialized.ssz_snappy",
@@ -56,7 +56,7 @@ fn test_uints_uint_16_zero_4() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -64,7 +64,7 @@ fn test_uints_uint_16_zero_4() {
 
 #[test]
 fn test_uints_uint_128_random_2() {
-    let value = 1966913376797472348559631900882537126;
+    let mut value = 1966913376797472348559631900882537126;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_random_2/serialized.ssz_snappy",
@@ -74,7 +74,7 @@ fn test_uints_uint_128_random_2() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a68a04f1c6f71282ca13121251d07a0100000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -82,7 +82,7 @@ fn test_uints_uint_128_random_2() {
 
 #[test]
 fn test_uints_uint_32_max_0() {
-    let value = 4294967295;
+    let mut value = 4294967295;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_max_0/serialized.ssz_snappy",
@@ -92,7 +92,7 @@ fn test_uints_uint_32_max_0() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -100,7 +100,7 @@ fn test_uints_uint_32_max_0() {
 
 #[test]
 fn test_uints_uint_16_random_1() {
-    let value = 12900;
+    let mut value = 12900;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_random_1/serialized.ssz_snappy",
@@ -110,7 +110,7 @@ fn test_uints_uint_16_random_1() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("6432000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -118,7 +118,7 @@ fn test_uints_uint_16_random_1() {
 
 #[test]
 fn test_uints_uint_32_zero_3() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_zero_3/serialized.ssz_snappy",
@@ -128,7 +128,7 @@ fn test_uints_uint_32_zero_3() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -136,7 +136,7 @@ fn test_uints_uint_32_zero_3() {
 
 #[test]
 fn test_uints_uint_8_random_0() {
-    let value = 225;
+    let mut value = 225;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_random_0/serialized.ssz_snappy",
@@ -146,7 +146,7 @@ fn test_uints_uint_8_random_0() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -154,7 +154,7 @@ fn test_uints_uint_8_random_0() {
 
 #[test]
 fn test_uints_uint_16_max_0() {
-    let value = 65535;
+    let mut value = 65535;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_max_0/serialized.ssz_snappy",
@@ -164,7 +164,7 @@ fn test_uints_uint_16_max_0() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -172,7 +172,7 @@ fn test_uints_uint_16_max_0() {
 
 #[test]
 fn test_uints_uint_128_zero_4() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_zero_4/serialized.ssz_snappy",
@@ -182,7 +182,7 @@ fn test_uints_uint_128_zero_4() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -190,7 +190,7 @@ fn test_uints_uint_128_zero_4() {
 
 #[test]
 fn test_uints_uint_32_zero_4() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_zero_4/serialized.ssz_snappy",
@@ -200,7 +200,7 @@ fn test_uints_uint_32_zero_4() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -208,7 +208,7 @@ fn test_uints_uint_32_zero_4() {
 
 #[test]
 fn test_uints_uint_128_zero_3() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_zero_3/serialized.ssz_snappy",
@@ -218,7 +218,7 @@ fn test_uints_uint_128_zero_3() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -226,7 +226,7 @@ fn test_uints_uint_128_zero_3() {
 
 #[test]
 fn test_uints_uint_16_random_0() {
-    let value = 11001;
+    let mut value = 11001;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_random_0/serialized.ssz_snappy",
@@ -236,7 +236,7 @@ fn test_uints_uint_16_random_0() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("f92a000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -244,7 +244,7 @@ fn test_uints_uint_16_random_0() {
 
 #[test]
 fn test_uints_uint_32_max_1() {
-    let value = 4294967295;
+    let mut value = 4294967295;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_max_1/serialized.ssz_snappy",
@@ -254,7 +254,7 @@ fn test_uints_uint_32_max_1() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -262,7 +262,7 @@ fn test_uints_uint_32_max_1() {
 
 #[test]
 fn test_uints_uint_256_zero_4() {
-    let value = U256([
+    let mut value = U256([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ]);
@@ -275,7 +275,7 @@ fn test_uints_uint_256_zero_4() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -283,7 +283,7 @@ fn test_uints_uint_256_zero_4() {
 
 #[test]
 fn test_uints_uint_128_random_3() {
-    let value = 223686144064414504608552983434269426145;
+    let mut value = 223686144064414504608552983434269426145;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_random_3/serialized.ssz_snappy",
@@ -293,7 +293,7 @@ fn test_uints_uint_128_random_3() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e101ce24c16ec3b57c2f0b79616248a800000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -301,7 +301,7 @@ fn test_uints_uint_128_random_3() {
 
 #[test]
 fn test_uints_uint_128_random_4() {
-    let value = 199925590919705556758473559487562637786;
+    let mut value = 199925590919705556758473559487562637786;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_random_4/serialized.ssz_snappy",
@@ -311,7 +311,7 @@ fn test_uints_uint_128_random_4() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("dae1c72a086dde0deb118413aa44689600000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -319,7 +319,7 @@ fn test_uints_uint_128_random_4() {
 
 #[test]
 fn test_uints_uint_256_zero_3() {
-    let value = U256([
+    let mut value = U256([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ]);
@@ -332,7 +332,7 @@ fn test_uints_uint_256_zero_3() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -340,7 +340,7 @@ fn test_uints_uint_256_zero_3() {
 
 #[test]
 fn test_uints_uint_16_zero_2() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_zero_2/serialized.ssz_snappy",
@@ -350,7 +350,7 @@ fn test_uints_uint_16_zero_2() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -358,7 +358,7 @@ fn test_uints_uint_16_zero_2() {
 
 #[test]
 fn test_uints_uint_128_zero_2() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_zero_2/serialized.ssz_snappy",
@@ -368,7 +368,7 @@ fn test_uints_uint_128_zero_2() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -376,7 +376,7 @@ fn test_uints_uint_128_zero_2() {
 
 #[test]
 fn test_uints_uint_16_max_1() {
-    let value = 65535;
+    let mut value = 65535;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_max_1/serialized.ssz_snappy",
@@ -386,7 +386,7 @@ fn test_uints_uint_16_max_1() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -394,7 +394,7 @@ fn test_uints_uint_16_max_1() {
 
 #[test]
 fn test_uints_uint_8_random_1() {
-    let value = 59;
+    let mut value = 59;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_random_1/serialized.ssz_snappy",
@@ -404,7 +404,7 @@ fn test_uints_uint_8_random_1() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3b00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -412,7 +412,7 @@ fn test_uints_uint_8_random_1() {
 
 #[test]
 fn test_uints_uint_32_zero_2() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_zero_2/serialized.ssz_snappy",
@@ -422,7 +422,7 @@ fn test_uints_uint_32_zero_2() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -430,7 +430,7 @@ fn test_uints_uint_32_zero_2() {
 
 #[test]
 fn test_uints_uint_64_zero_0() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_zero_0/serialized.ssz_snappy",
@@ -440,7 +440,7 @@ fn test_uints_uint_64_zero_0() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -448,7 +448,7 @@ fn test_uints_uint_64_zero_0() {
 
 #[test]
 fn test_uints_uint_128_max_2() {
-    let value = 340282366920938463463374607431768211455;
+    let mut value = 340282366920938463463374607431768211455;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_max_2/serialized.ssz_snappy",
@@ -458,7 +458,7 @@ fn test_uints_uint_128_max_2() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -466,7 +466,7 @@ fn test_uints_uint_128_max_2() {
 
 #[test]
 fn test_uints_uint_8_max_1() {
-    let value = 255;
+    let mut value = 255;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_max_1/serialized.ssz_snappy",
@@ -476,7 +476,7 @@ fn test_uints_uint_8_max_1() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -484,7 +484,7 @@ fn test_uints_uint_8_max_1() {
 
 #[test]
 fn test_uints_uint_128_max_3() {
-    let value = 340282366920938463463374607431768211455;
+    let mut value = 340282366920938463463374607431768211455;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_max_3/serialized.ssz_snappy",
@@ -494,7 +494,7 @@ fn test_uints_uint_128_max_3() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -502,7 +502,7 @@ fn test_uints_uint_128_max_3() {
 
 #[test]
 fn test_uints_uint_256_last_byte_empty() {
-    let value = U256([
+    let mut value = U256([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0,
     ]);
@@ -515,7 +515,7 @@ fn test_uints_uint_256_last_byte_empty() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00");
     assert_eq!(root, expected_root);
@@ -523,7 +523,7 @@ fn test_uints_uint_256_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_128_max_4() {
-    let value = 340282366920938463463374607431768211455;
+    let mut value = 340282366920938463463374607431768211455;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_max_4/serialized.ssz_snappy",
@@ -533,7 +533,7 @@ fn test_uints_uint_128_max_4() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -541,7 +541,7 @@ fn test_uints_uint_128_max_4() {
 
 #[test]
 fn test_uints_uint_64_zero_1() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_zero_1/serialized.ssz_snappy",
@@ -551,7 +551,7 @@ fn test_uints_uint_64_zero_1() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -559,7 +559,7 @@ fn test_uints_uint_64_zero_1() {
 
 #[test]
 fn test_uints_uint_8_max_0() {
-    let value = 255;
+    let mut value = 255;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_max_0/serialized.ssz_snappy",
@@ -569,7 +569,7 @@ fn test_uints_uint_8_max_0() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -577,7 +577,7 @@ fn test_uints_uint_8_max_0() {
 
 #[test]
 fn test_uints_uint_256_max_4() {
-    let value = U256([
+    let mut value = U256([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ]);
@@ -590,7 +590,7 @@ fn test_uints_uint_256_max_4() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -598,7 +598,7 @@ fn test_uints_uint_256_max_4() {
 
 #[test]
 fn test_uints_uint_8_zero_0() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_zero_0/serialized.ssz_snappy",
@@ -608,7 +608,7 @@ fn test_uints_uint_8_zero_0() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -616,7 +616,7 @@ fn test_uints_uint_8_zero_0() {
 
 #[test]
 fn test_uints_uint_256_random_2() {
-    let value = U256([
+    let mut value = U256([
         145, 36, 54, 124, 134, 65, 119, 96, 224, 3, 87, 209, 164, 118, 23, 209, 5, 72, 9, 168, 251,
         195, 102, 65, 122, 101, 27, 164, 66, 115, 0, 49,
     ]);
@@ -629,7 +629,7 @@ fn test_uints_uint_256_random_2() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("9124367c86417760e00357d1a47617d1054809a8fbc366417a651ba442730031");
     assert_eq!(root, expected_root);
@@ -637,7 +637,7 @@ fn test_uints_uint_256_random_2() {
 
 #[test]
 fn test_uints_uint_64_random_3() {
-    let value = 11891402719218752485;
+    let mut value = 11891402719218752485;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_random_3/serialized.ssz_snappy",
@@ -647,7 +647,7 @@ fn test_uints_uint_64_random_3() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("e5db2510c5bf06a5000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -655,7 +655,7 @@ fn test_uints_uint_64_random_3() {
 
 #[test]
 fn test_uints_uint_256_max_3() {
-    let value = U256([
+    let mut value = U256([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ]);
@@ -668,7 +668,7 @@ fn test_uints_uint_256_max_3() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -676,7 +676,7 @@ fn test_uints_uint_256_max_3() {
 
 #[test]
 fn test_uints_uint_64_random_4() {
-    let value = 15683022699148686111;
+    let mut value = 15683022699148686111;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_random_4/serialized.ssz_snappy",
@@ -686,7 +686,7 @@ fn test_uints_uint_64_random_4() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1f33257b0d4aa5d9000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -694,7 +694,7 @@ fn test_uints_uint_64_random_4() {
 
 #[test]
 fn test_uints_uint_64_max_2() {
-    let value = 18446744073709551615;
+    let mut value = 18446744073709551615;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_max_2/serialized.ssz_snappy",
@@ -704,7 +704,7 @@ fn test_uints_uint_64_max_2() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -712,7 +712,7 @@ fn test_uints_uint_64_max_2() {
 
 #[test]
 fn test_uints_uint_32_random_0() {
-    let value = 3387753032;
+    let mut value = 3387753032;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_random_0/serialized.ssz_snappy",
@@ -722,7 +722,7 @@ fn test_uints_uint_32_random_0() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("4802edc900000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -730,7 +730,7 @@ fn test_uints_uint_32_random_0() {
 
 #[test]
 fn test_uints_uint_256_max_2() {
-    let value = U256([
+    let mut value = U256([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ]);
@@ -743,7 +743,7 @@ fn test_uints_uint_256_max_2() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -751,7 +751,7 @@ fn test_uints_uint_256_max_2() {
 
 #[test]
 fn test_uints_uint_256_random_4() {
-    let value = U256([
+    let mut value = U256([
         236, 44, 123, 92, 134, 169, 87, 238, 98, 219, 210, 219, 26, 37, 128, 52, 156, 71, 217, 131,
         206, 187, 193, 227, 34, 128, 209, 179, 17, 9, 210, 107,
     ]);
@@ -764,7 +764,7 @@ fn test_uints_uint_256_random_4() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ec2c7b5c86a957ee62dbd2db1a2580349c47d983cebbc1e32280d1b31109d26b");
     assert_eq!(root, expected_root);
@@ -772,7 +772,7 @@ fn test_uints_uint_256_random_4() {
 
 #[test]
 fn test_uints_uint_8_zero_1() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_zero_1/serialized.ssz_snappy",
@@ -782,7 +782,7 @@ fn test_uints_uint_8_zero_1() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -790,7 +790,7 @@ fn test_uints_uint_8_zero_1() {
 
 #[test]
 fn test_uints_uint_256_random_3() {
-    let value = U256([
+    let mut value = U256([
         9, 220, 230, 65, 45, 6, 68, 219, 208, 26, 176, 18, 183, 94, 87, 176, 157, 70, 34, 109, 52,
         201, 18, 243, 217, 129, 175, 51, 196, 80, 238, 25,
     ]);
@@ -803,7 +803,7 @@ fn test_uints_uint_256_random_3() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("09dce6412d0644dbd01ab012b75e57b09d46226d34c912f3d981af33c450ee19");
     assert_eq!(root, expected_root);
@@ -811,7 +811,7 @@ fn test_uints_uint_256_random_3() {
 
 #[test]
 fn test_uints_uint_64_random_2() {
-    let value = 10680714365983390887;
+    let mut value = 10680714365983390887;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_random_2/serialized.ssz_snappy",
@@ -821,7 +821,7 @@ fn test_uints_uint_64_random_2() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a7fcd98320853994000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -829,7 +829,7 @@ fn test_uints_uint_64_random_2() {
 
 #[test]
 fn test_uints_uint_32_random_1() {
-    let value = 2676973563;
+    let mut value = 2676973563;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_random_1/serialized.ssz_snappy",
@@ -839,7 +839,7 @@ fn test_uints_uint_32_random_1() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fb5f8f9f00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -847,7 +847,7 @@ fn test_uints_uint_32_random_1() {
 
 #[test]
 fn test_uints_uint_64_max_4() {
-    let value = 18446744073709551615;
+    let mut value = 18446744073709551615;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_max_4/serialized.ssz_snappy",
@@ -857,7 +857,7 @@ fn test_uints_uint_64_max_4() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -865,7 +865,7 @@ fn test_uints_uint_64_max_4() {
 
 #[test]
 fn test_uints_uint_64_max_3() {
-    let value = 18446744073709551615;
+    let mut value = 18446744073709551615;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_max_3/serialized.ssz_snappy",
@@ -875,7 +875,7 @@ fn test_uints_uint_64_max_3() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -883,7 +883,7 @@ fn test_uints_uint_64_max_3() {
 
 #[test]
 fn test_uints_uint_8_last_byte_empty() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_last_byte_empty/serialized.ssz_snappy",
@@ -893,7 +893,7 @@ fn test_uints_uint_8_last_byte_empty() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -901,7 +901,7 @@ fn test_uints_uint_8_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_8_random_4() {
-    let value = 17;
+    let mut value = 17;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_random_4/serialized.ssz_snappy",
@@ -911,7 +911,7 @@ fn test_uints_uint_8_random_4() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("1100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -919,7 +919,7 @@ fn test_uints_uint_8_random_4() {
 
 #[test]
 fn test_uints_uint_16_max_4() {
-    let value = 65535;
+    let mut value = 65535;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_max_4/serialized.ssz_snappy",
@@ -929,7 +929,7 @@ fn test_uints_uint_16_max_4() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -937,7 +937,7 @@ fn test_uints_uint_16_max_4() {
 
 #[test]
 fn test_uints_uint_128_zero_0() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_zero_0/serialized.ssz_snappy",
@@ -947,7 +947,7 @@ fn test_uints_uint_128_zero_0() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -955,7 +955,7 @@ fn test_uints_uint_128_zero_0() {
 
 #[test]
 fn test_uints_uint_32_zero_0() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_zero_0/serialized.ssz_snappy",
@@ -965,7 +965,7 @@ fn test_uints_uint_32_zero_0() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -973,7 +973,7 @@ fn test_uints_uint_32_zero_0() {
 
 #[test]
 fn test_uints_uint_8_random_3() {
-    let value = 46;
+    let mut value = 46;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_random_3/serialized.ssz_snappy",
@@ -983,7 +983,7 @@ fn test_uints_uint_8_random_3() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("2e00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -991,7 +991,7 @@ fn test_uints_uint_8_random_3() {
 
 #[test]
 fn test_uints_uint_16_max_3() {
-    let value = 65535;
+    let mut value = 65535;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_max_3/serialized.ssz_snappy",
@@ -1001,7 +1001,7 @@ fn test_uints_uint_16_max_3() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1009,7 +1009,7 @@ fn test_uints_uint_16_max_3() {
 
 #[test]
 fn test_uints_uint_128_random_1() {
-    let value = 226427817519480008631815531407103573168;
+    let mut value = 226427817519480008631815531407103573168;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_random_1/serialized.ssz_snappy",
@@ -1019,7 +1019,7 @@ fn test_uints_uint_128_random_1() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("b03c1174ebe365e018a5b887516958aa00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1027,7 +1027,7 @@ fn test_uints_uint_128_random_1() {
 
 #[test]
 fn test_uints_uint_256_zero_1() {
-    let value = U256([
+    let mut value = U256([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ]);
@@ -1040,7 +1040,7 @@ fn test_uints_uint_256_zero_1() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1048,7 +1048,7 @@ fn test_uints_uint_256_zero_1() {
 
 #[test]
 fn test_uints_uint_16_zero_0() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_zero_0/serialized.ssz_snappy",
@@ -1058,7 +1058,7 @@ fn test_uints_uint_16_zero_0() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1066,7 +1066,7 @@ fn test_uints_uint_16_zero_0() {
 
 #[test]
 fn test_uints_uint_16_random_2() {
-    let value = 46482;
+    let mut value = 46482;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_random_2/serialized.ssz_snappy",
@@ -1076,7 +1076,7 @@ fn test_uints_uint_16_random_2() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("92b5000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1084,7 +1084,7 @@ fn test_uints_uint_16_random_2() {
 
 #[test]
 fn test_uints_uint_32_max_4() {
-    let value = 4294967295;
+    let mut value = 4294967295;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_max_4/serialized.ssz_snappy",
@@ -1094,7 +1094,7 @@ fn test_uints_uint_32_max_4() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1102,7 +1102,7 @@ fn test_uints_uint_32_max_4() {
 
 #[test]
 fn test_uints_uint_32_max_3() {
-    let value = 4294967295;
+    let mut value = 4294967295;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_max_3/serialized.ssz_snappy",
@@ -1112,7 +1112,7 @@ fn test_uints_uint_32_max_3() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1120,7 +1120,7 @@ fn test_uints_uint_32_max_3() {
 
 #[test]
 fn test_uints_uint_16_max_2() {
-    let value = 65535;
+    let mut value = 65535;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_max_2/serialized.ssz_snappy",
@@ -1130,7 +1130,7 @@ fn test_uints_uint_16_max_2() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1138,7 +1138,7 @@ fn test_uints_uint_16_max_2() {
 
 #[test]
 fn test_uints_uint_8_random_2() {
-    let value = 3;
+    let mut value = 3;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_random_2/serialized.ssz_snappy",
@@ -1148,7 +1148,7 @@ fn test_uints_uint_8_random_2() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1156,7 +1156,7 @@ fn test_uints_uint_8_random_2() {
 
 #[test]
 fn test_uints_uint_32_zero_1() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_zero_1/serialized.ssz_snappy",
@@ -1166,7 +1166,7 @@ fn test_uints_uint_32_zero_1() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1174,7 +1174,7 @@ fn test_uints_uint_32_zero_1() {
 
 #[test]
 fn test_uints_uint_128_zero_1() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_zero_1/serialized.ssz_snappy",
@@ -1184,7 +1184,7 @@ fn test_uints_uint_128_zero_1() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1192,7 +1192,7 @@ fn test_uints_uint_128_zero_1() {
 
 #[test]
 fn test_uints_uint_16_random_4() {
-    let value = 2284;
+    let mut value = 2284;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_random_4/serialized.ssz_snappy",
@@ -1202,7 +1202,7 @@ fn test_uints_uint_16_random_4() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ec08000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1210,7 +1210,7 @@ fn test_uints_uint_16_random_4() {
 
 #[test]
 fn test_uints_uint_32_max_2() {
-    let value = 4294967295;
+    let mut value = 4294967295;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_max_2/serialized.ssz_snappy",
@@ -1220,7 +1220,7 @@ fn test_uints_uint_32_max_2() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1228,7 +1228,7 @@ fn test_uints_uint_32_max_2() {
 
 #[test]
 fn test_uints_uint_16_random_3() {
-    let value = 31039;
+    let mut value = 31039;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_random_3/serialized.ssz_snappy",
@@ -1238,7 +1238,7 @@ fn test_uints_uint_16_random_3() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3f79000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1246,7 +1246,7 @@ fn test_uints_uint_16_random_3() {
 
 #[test]
 fn test_uints_uint_256_zero_0() {
-    let value = U256([
+    let mut value = U256([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ]);
@@ -1259,7 +1259,7 @@ fn test_uints_uint_256_zero_0() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1267,7 +1267,7 @@ fn test_uints_uint_256_zero_0() {
 
 #[test]
 fn test_uints_uint_16_zero_1() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_zero_1/serialized.ssz_snappy",
@@ -1277,7 +1277,7 @@ fn test_uints_uint_16_zero_1() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1285,7 +1285,7 @@ fn test_uints_uint_16_zero_1() {
 
 #[test]
 fn test_uints_uint_128_random_0() {
-    let value = 317658863013703600909281237913711302754;
+    let mut value = 317658863013703600909281237913711302754;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_random_0/serialized.ssz_snappy",
@@ -1295,7 +1295,7 @@ fn test_uints_uint_128_random_0() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("62583644e66ec83fc2a6cda723dffaee00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1303,7 +1303,7 @@ fn test_uints_uint_128_random_0() {
 
 #[test]
 fn test_uints_uint_8_max_2() {
-    let value = 255;
+    let mut value = 255;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_max_2/serialized.ssz_snappy",
@@ -1313,7 +1313,7 @@ fn test_uints_uint_8_max_2() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1321,7 +1321,7 @@ fn test_uints_uint_8_max_2() {
 
 #[test]
 fn test_uints_uint_64_zero_4() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_zero_4/serialized.ssz_snappy",
@@ -1331,7 +1331,7 @@ fn test_uints_uint_64_zero_4() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1339,7 +1339,7 @@ fn test_uints_uint_64_zero_4() {
 
 #[test]
 fn test_uints_uint_64_zero_3() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_zero_3/serialized.ssz_snappy",
@@ -1349,7 +1349,7 @@ fn test_uints_uint_64_zero_3() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1357,7 +1357,7 @@ fn test_uints_uint_64_zero_3() {
 
 #[test]
 fn test_uints_uint_128_max_1() {
-    let value = 340282366920938463463374607431768211455;
+    let mut value = 340282366920938463463374607431768211455;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_max_1/serialized.ssz_snappy",
@@ -1367,7 +1367,7 @@ fn test_uints_uint_128_max_1() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1375,7 +1375,7 @@ fn test_uints_uint_128_max_1() {
 
 #[test]
 fn test_uints_uint_8_max_3() {
-    let value = 255;
+    let mut value = 255;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_max_3/serialized.ssz_snappy",
@@ -1385,7 +1385,7 @@ fn test_uints_uint_8_max_3() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1393,7 +1393,7 @@ fn test_uints_uint_8_max_3() {
 
 #[test]
 fn test_uints_uint_8_max_4() {
-    let value = 255;
+    let mut value = 255;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_max_4/serialized.ssz_snappy",
@@ -1403,7 +1403,7 @@ fn test_uints_uint_8_max_4() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1411,7 +1411,7 @@ fn test_uints_uint_8_max_4() {
 
 #[test]
 fn test_uints_uint_128_max_0() {
-    let value = 340282366920938463463374607431768211455;
+    let mut value = 340282366920938463463374607431768211455;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_max_0/serialized.ssz_snappy",
@@ -1421,7 +1421,7 @@ fn test_uints_uint_128_max_0() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1429,7 +1429,7 @@ fn test_uints_uint_128_max_0() {
 
 #[test]
 fn test_uints_uint_64_zero_2() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_zero_2/serialized.ssz_snappy",
@@ -1439,7 +1439,7 @@ fn test_uints_uint_64_zero_2() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1447,7 +1447,7 @@ fn test_uints_uint_64_zero_2() {
 
 #[test]
 fn test_uints_uint_32_random_3() {
-    let value = 638037343;
+    let mut value = 638037343;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_random_3/serialized.ssz_snappy",
@@ -1457,7 +1457,7 @@ fn test_uints_uint_32_random_3() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("5fad072600000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1465,7 +1465,7 @@ fn test_uints_uint_32_random_3() {
 
 #[test]
 fn test_uints_uint_32_random_4() {
-    let value = 4144220671;
+    let mut value = 4144220671;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_random_4/serialized.ssz_snappy",
@@ -1475,7 +1475,7 @@ fn test_uints_uint_32_random_4() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffc903f700000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1483,7 +1483,7 @@ fn test_uints_uint_32_random_4() {
 
 #[test]
 fn test_uints_uint_64_max_1() {
-    let value = 18446744073709551615;
+    let mut value = 18446744073709551615;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_max_1/serialized.ssz_snappy",
@@ -1493,7 +1493,7 @@ fn test_uints_uint_64_max_1() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1501,7 +1501,7 @@ fn test_uints_uint_64_max_1() {
 
 #[test]
 fn test_uints_uint_32_last_byte_empty() {
-    let value = 16777215;
+    let mut value = 16777215;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_last_byte_empty/serialized.ssz_snappy",
@@ -1511,7 +1511,7 @@ fn test_uints_uint_32_last_byte_empty() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffff0000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1519,7 +1519,7 @@ fn test_uints_uint_32_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_128_last_byte_empty() {
-    let value = 1329227995784915872903807060280344575;
+    let mut value = 1329227995784915872903807060280344575;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_128_last_byte_empty/serialized.ssz_snappy",
@@ -1529,7 +1529,7 @@ fn test_uints_uint_128_last_byte_empty() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffff0000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1537,7 +1537,7 @@ fn test_uints_uint_128_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_16_last_byte_empty() {
-    let value = 255;
+    let mut value = 255;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_16_last_byte_empty/serialized.ssz_snappy",
@@ -1547,7 +1547,7 @@ fn test_uints_uint_16_last_byte_empty() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1555,7 +1555,7 @@ fn test_uints_uint_16_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_8_zero_4() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_zero_4/serialized.ssz_snappy",
@@ -1565,7 +1565,7 @@ fn test_uints_uint_8_zero_4() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1573,7 +1573,7 @@ fn test_uints_uint_8_zero_4() {
 
 #[test]
 fn test_uints_uint_256_max_0() {
-    let value = U256([
+    let mut value = U256([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ]);
@@ -1586,7 +1586,7 @@ fn test_uints_uint_256_max_0() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -1594,7 +1594,7 @@ fn test_uints_uint_256_max_0() {
 
 #[test]
 fn test_uints_uint_8_zero_3() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_zero_3/serialized.ssz_snappy",
@@ -1604,7 +1604,7 @@ fn test_uints_uint_8_zero_3() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1612,7 +1612,7 @@ fn test_uints_uint_8_zero_3() {
 
 #[test]
 fn test_uints_uint_256_random_1() {
-    let value = U256([
+    let mut value = U256([
         160, 200, 243, 199, 115, 30, 235, 132, 127, 224, 146, 208, 192, 97, 24, 112, 2, 157, 177,
         75, 95, 22, 105, 70, 180, 97, 182, 31, 39, 79, 21, 199,
     ]);
@@ -1625,7 +1625,7 @@ fn test_uints_uint_256_random_1() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("a0c8f3c7731eeb847fe092d0c0611870029db14b5f166946b461b61f274f15c7");
     assert_eq!(root, expected_root);
@@ -1633,7 +1633,7 @@ fn test_uints_uint_256_random_1() {
 
 #[test]
 fn test_uints_uint_64_random_0() {
-    let value = 8594311575614880821;
+    let mut value = 8594311575614880821;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_random_0/serialized.ssz_snappy",
@@ -1643,7 +1643,7 @@ fn test_uints_uint_64_random_0() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("357c8de9d7204577000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1651,7 +1651,7 @@ fn test_uints_uint_64_random_0() {
 
 #[test]
 fn test_uints_uint_64_max_0() {
-    let value = 18446744073709551615;
+    let mut value = 18446744073709551615;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_max_0/serialized.ssz_snappy",
@@ -1661,7 +1661,7 @@ fn test_uints_uint_64_max_0() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1669,7 +1669,7 @@ fn test_uints_uint_64_max_0() {
 
 #[test]
 fn test_uints_uint_32_random_2() {
-    let value = 2644908285;
+    let mut value = 2644908285;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_32_random_2/serialized.ssz_snappy",
@@ -1679,7 +1679,7 @@ fn test_uints_uint_32_random_2() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("fd18a69d00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1687,7 +1687,7 @@ fn test_uints_uint_32_random_2() {
 
 #[test]
 fn test_uints_uint_8_zero_2() {
-    let value = 0;
+    let mut value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_8_zero_2/serialized.ssz_snappy",
@@ -1697,7 +1697,7 @@ fn test_uints_uint_8_zero_2() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1705,7 +1705,7 @@ fn test_uints_uint_8_zero_2() {
 
 #[test]
 fn test_uints_uint_256_random_0() {
-    let value = U256([
+    let mut value = U256([
         58, 55, 99, 28, 168, 145, 249, 244, 255, 81, 153, 135, 170, 128, 39, 36, 202, 1, 166, 171,
         97, 55, 46, 78, 36, 161, 66, 116, 168, 139, 34, 10,
     ]);
@@ -1718,7 +1718,7 @@ fn test_uints_uint_256_random_0() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3a37631ca891f9f4ff519987aa802724ca01a6ab61372e4e24a14274a88b220a");
     assert_eq!(root, expected_root);
@@ -1726,7 +1726,7 @@ fn test_uints_uint_256_random_0() {
 
 #[test]
 fn test_uints_uint_64_random_1() {
-    let value = 12453893770581738044;
+    let mut value = 12453893770581738044;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_random_1/serialized.ssz_snappy",
@@ -1736,7 +1736,7 @@ fn test_uints_uint_64_random_1() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("3c82f999661ed5ac000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1744,7 +1744,7 @@ fn test_uints_uint_64_random_1() {
 
 #[test]
 fn test_uints_uint_256_max_1() {
-    let value = U256([
+    let mut value = U256([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ]);
@@ -1757,7 +1757,7 @@ fn test_uints_uint_256_max_1() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -1765,7 +1765,7 @@ fn test_uints_uint_256_max_1() {
 
 #[test]
 fn test_uints_uint_64_last_byte_empty() {
-    let value = 72057594037927935;
+    let mut value = 72057594037927935;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz_rs/tests/data/uints/valid/uint_64_last_byte_empty/serialized.ssz_snappy",
@@ -1775,7 +1775,7 @@ fn test_uints_uint_64_last_byte_empty() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&value);
+    let root = hash_tree_root(&mut value);
     let expected_root =
         root_from_hex("ffffffffffffff00000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);

--- a/ssz_rs_derive/src/lib.rs
+++ b/ssz_rs_derive/src/lib.rs
@@ -380,7 +380,7 @@ fn derive_merkleization_impl(data: &Data) -> TokenStream {
                 },
             });
             quote! {
-                fn hash_tree_root(&self, context: &ssz_rs::MerkleizationContext) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
+                fn hash_tree_root(&mut self, context: &ssz_rs::MerkleizationContext) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
                     let mut chunks = vec![0u8; #field_count * #BYTES_PER_CHUNK];
                     #(#impl_by_field)*
                     ssz_rs::internal::merkleize(&chunks, None, context)
@@ -413,7 +413,7 @@ fn derive_merkleization_impl(data: &Data) -> TokenStream {
                 }
             });
             quote! {
-                fn hash_tree_root(&self, context: &ssz_rs::MerkleizationContext) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
+                fn hash_tree_root(&mut self, context: &ssz_rs::MerkleizationContext) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
                     match self {
                             #(#hash_tree_root_by_variant)*
                     }


### PR DESCRIPTION
First of several PRs to add caching / merkle-backing for some SSZ types:

This PR adds some basic infrastructure and installs a "non-caching" merkle backing for the following types:
- Vectors
- Lists

Other types have relatively small Merkle trees in common usage so we can skip caching for now.

The intent here is to provide a Merkle backing for quick production of (multi)proofs along with caching to avoid expensive recomputation of hash tree root.

NOTE: there are also some other ergonomics improvements in this PR around mutating / manipulating Lists and Vectors so that the caching abstraction is sound.