### PR TITLE
deprecate Merkle `Context` in lieu of static data

### DIFF
--- a/ssz_rs/Cargo.toml
+++ b/ssz_rs/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1.0.25"
 bitvec = "0.22.3"
 ssz_rs_derive = { path = "../ssz_rs_derive", version = "0.7.0" }
 sha2 = "0.9.8"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 hex-literal = "0.3.3"

--- a/ssz_rs/examples/another_container.rs
+++ b/ssz_rs/examples/another_container.rs
@@ -98,8 +98,7 @@ fn main() {
         deserialize(&expected_encoding).expect("can deserialize");
     assert_eq!(recovered_value, value);
 
-    let context = MerkleizationContext::new();
-    let root = value.hash_tree_root(&context).expect("can find root");
+    let root = value.hash_tree_root().expect("can find root");
     let expected_root = "69b0ce69dfbc8abb8ae4fba564dcb813f5cc5b93c76d2b3d0689687c35821036";
     assert_eq!(hex::encode(root), expected_root);
 }

--- a/ssz_rs/examples/container_with_some_types.rs
+++ b/ssz_rs/examples/container_with_some_types.rs
@@ -24,7 +24,6 @@ struct Foo<const N: usize> {
 }
 
 fn main() {
-    let context = MerkleizationContext::new();
     let mut foo: Foo<4> = Foo {
         a: 16u32,
         b: Vector::from_iter([3u32, 2u32, 1u32, 10u32]),
@@ -39,7 +38,7 @@ fn main() {
     };
 
     println!("{:#?}", foo);
-    let root = foo.hash_tree_root(&context).expect("can make root");
+    let root = foo.hash_tree_root().expect("can make root");
     println!("{:#?}", root);
 
     foo.b[2] = 44u32;
@@ -68,8 +67,6 @@ fn main() {
     };
 
     println!("{:#?}", restored_foo);
-    let root = restored_foo
-        .hash_tree_root(&context)
-        .expect("can make root");
+    let root = restored_foo.hash_tree_root().expect("can make root");
     println!("{:?}", root);
 }

--- a/ssz_rs/src/array.rs
+++ b/ssz_rs/src/array.rs
@@ -5,7 +5,7 @@
 //! can likely be simplified to a definition over `const N: usize`.
 use crate::de::{deserialize_homogeneous_composite, Deserialize, DeserializeError};
 use crate::merkleization::{
-    merkleize, pack, Context, MerkleizationError, Merkleized, Node, BYTES_PER_CHUNK,
+    merkleize, pack, MerkleizationError, Merkleized, Node, BYTES_PER_CHUNK,
 };
 use crate::ser::{serialize_composite, Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
@@ -66,18 +66,18 @@ macro_rules! define_ssz_for_array_of_size {
         where
             T: SimpleSerialize,
         {
-            fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
+            fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
                 if T::is_composite_type() {
                     let mut chunks = vec![0u8; self.len() * BYTES_PER_CHUNK];
                     for (i, elem) in self.iter_mut().enumerate() {
-                        let chunk = elem.hash_tree_root(context)?;
+                        let chunk = elem.hash_tree_root()?;
                         let range = i * BYTES_PER_CHUNK..(i + 1) * BYTES_PER_CHUNK;
                         chunks[range].copy_from_slice(chunk.as_ref());
                     }
-                    merkleize(&chunks, None, context)
+                    merkleize(&chunks, None)
                 } else {
                     let chunks = pack(self)?;
-                    merkleize(&chunks, None, context)
+                    merkleize(&chunks, None)
                 }
             }
         }

--- a/ssz_rs/src/bitlist.rs
+++ b/ssz_rs/src/bitlist.rs
@@ -1,6 +1,6 @@
 use crate::de::{Deserialize, DeserializeError};
 use crate::merkleization::{
-    merkleize, mix_in_length, pack_bytes, Context, MerkleizationError, Merkleized, Node,
+    merkleize, mix_in_length, pack_bytes, MerkleizationError, Merkleized, Node,
 };
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
@@ -154,10 +154,10 @@ impl<const N: usize> Deserialize for Bitlist<N> {
 }
 
 impl<const N: usize> Merkleized for Bitlist<N> {
-    fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
         let chunks = self.pack_bits()?;
-        let data_root = merkleize(&chunks, Some((N + 255) / 256), context)?;
-        Ok(mix_in_length(&data_root, self.len(), context))
+        let data_root = merkleize(&chunks, Some((N + 255) / 256))?;
+        Ok(mix_in_length(&data_root, self.len()))
     }
 }
 

--- a/ssz_rs/src/bitvector.rs
+++ b/ssz_rs/src/bitvector.rs
@@ -1,5 +1,5 @@
 use crate::de::{Deserialize, DeserializeError};
-use crate::merkleization::{merkleize, pack_bytes, Context, MerkleizationError, Merkleized, Node};
+use crate::merkleization::{merkleize, pack_bytes, MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
 use bitvec::field::BitField;
@@ -140,9 +140,9 @@ impl<const N: usize> Deserialize for Bitvector<N> {
 }
 
 impl<const N: usize> Merkleized for Bitvector<N> {
-    fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
         let chunks = self.pack_bits()?;
-        merkleize(&chunks, Some((N + 255) / 256), context)
+        merkleize(&chunks, Some((N + 255) / 256))
     }
 }
 

--- a/ssz_rs/src/boolean.rs
+++ b/ssz_rs/src/boolean.rs
@@ -1,5 +1,5 @@
 use crate::de::{Deserialize, DeserializeError};
-use crate::merkleization::{Context, MerkleizationError, Merkleized, Node};
+use crate::merkleization::{MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
 
@@ -36,7 +36,7 @@ impl Deserialize for bool {
 }
 
 impl Merkleized for bool {
-    fn hash_tree_root(&mut self, _context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
         if *self {
             let mut root = Node::default();
             root[0] = 1u8;

--- a/ssz_rs/src/list.rs
+++ b/ssz_rs/src/list.rs
@@ -1,6 +1,6 @@
 use crate::de::{deserialize_homogeneous_composite, Deserialize, DeserializeError};
 use crate::merkleization::{
-    merkleize, mix_in_length, pack, Context, MerkleCache, MerkleizationError, Merkleized, Node,
+    merkleize, mix_in_length, pack, MerkleCache, MerkleizationError, Merkleized, Node,
     BYTES_PER_CHUNK,
 };
 use crate::ser::{serialize_composite, Serialize, SerializeError};
@@ -173,21 +173,21 @@ where
         }
     }
 
-    fn compute_hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
+    fn compute_hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
         if T::is_composite_type() {
             let mut chunks = Vec::with_capacity(self.len() * BYTES_PER_CHUNK);
             for (i, elem) in self.data.iter_mut().enumerate() {
-                let chunk = elem.hash_tree_root(context)?;
+                let chunk = elem.hash_tree_root()?;
                 let range = i * BYTES_PER_CHUNK..(i + 1) * BYTES_PER_CHUNK;
                 chunks[range].copy_from_slice(chunk.as_ref());
             }
-            let data_root = merkleize(&chunks, Some(N), context)?;
-            Ok(mix_in_length(&data_root, self.len(), context))
+            let data_root = merkleize(&chunks, Some(N))?;
+            Ok(mix_in_length(&data_root, self.len()))
         } else {
             let chunks = pack(self)?;
             let chunk_count = (N * T::size_hint() + 31) / 32;
-            let data_root = merkleize(&chunks, Some(chunk_count), context)?;
-            Ok(mix_in_length(&data_root, self.len(), context))
+            let data_root = merkleize(&chunks, Some(chunk_count))?;
+            Ok(mix_in_length(&data_root, self.len()))
         }
     }
 
@@ -207,8 +207,8 @@ impl<T, const N: usize> Merkleized for List<T, N>
 where
     T: SimpleSerialize,
 {
-    fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
-        self.compute_hash_tree_root(context)
+    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
+        self.compute_hash_tree_root()
     }
 }
 

--- a/ssz_rs/src/uint.rs
+++ b/ssz_rs/src/uint.rs
@@ -1,5 +1,5 @@
 use crate::de::{Deserialize, DeserializeError};
-use crate::merkleization::{pack_bytes, Context, MerkleizationError, Merkleized, Node};
+use crate::merkleization::{pack_bytes, MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
 use std::convert::TryInto;
@@ -42,7 +42,7 @@ macro_rules! define_uint {
         }
 
         impl Merkleized for $uint {
-            fn hash_tree_root(&mut self, _context: &Context) -> Result<Node, MerkleizationError> {
+            fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
                 let mut root = vec![];
                 let _ = self.serialize(&mut root)?;
                 pack_bytes(&mut root);
@@ -102,7 +102,7 @@ impl Deserialize for U256 {
 }
 
 impl Merkleized for U256 {
-    fn hash_tree_root(&mut self, _context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
         Ok(Node::from_bytes(self.0))
     }
 }

--- a/ssz_rs/src/union.rs
+++ b/ssz_rs/src/union.rs
@@ -1,5 +1,5 @@
 use crate::de::{Deserialize, DeserializeError};
-use crate::merkleization::{mix_in_selector, Context, MerkleizationError, Merkleized, Node};
+use crate::merkleization::{mix_in_selector, MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
 
@@ -59,10 +59,10 @@ impl<T> Merkleized for Option<T>
 where
     T: SimpleSerialize,
 {
-    fn hash_tree_root(&mut self, context: &Context) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
         match self {
-            Some(value) => Ok(mix_in_selector(&value.hash_tree_root(context)?, 1, context)),
-            None => Ok(mix_in_selector(&Node::default(), 0, context)),
+            Some(value) => Ok(mix_in_selector(&value.hash_tree_root()?, 1)),
+            None => Ok(mix_in_selector(&Node::default(), 0)),
         }
     }
 }

--- a/ssz_rs/tests/test_utils.rs
+++ b/ssz_rs/tests/test_utils.rs
@@ -24,8 +24,7 @@ pub fn deserialize<T: SimpleSerialize>(encoding: &[u8]) -> T {
 }
 
 pub fn hash_tree_root<T: SimpleSerialize>(value: &mut T) -> Node {
-    let context = MerkleizationContext::new();
-    value.hash_tree_root(&context).expect("can compute root")
+    value.hash_tree_root().expect("can compute root")
 }
 
 // Return SSZ-encoded bytes from test file at `target_path`

--- a/ssz_rs_derive/src/lib.rs
+++ b/ssz_rs_derive/src/lib.rs
@@ -369,21 +369,21 @@ fn derive_merkleization_impl(data: &Data) -> TokenStream {
             let field_count = fields.iter().len();
             let impl_by_field = fields.iter().enumerate().map(|(i, f)| match &f.ident {
                 Some(field_name) => quote_spanned! { f.span() =>
-                    let chunk = self.#field_name.hash_tree_root(context)?;
+                    let chunk = self.#field_name.hash_tree_root()?;
                     let range = #i*#BYTES_PER_CHUNK..(#i+1)*#BYTES_PER_CHUNK;
                     chunks[range].copy_from_slice(chunk.as_ref());
                 },
                 None => quote_spanned! { f.span() =>
-                    let chunk = self.0.hash_tree_root(context)?;
+                    let chunk = self.0.hash_tree_root()?;
                     let range = #i*#BYTES_PER_CHUNK..(#i+1)*#BYTES_PER_CHUNK;
                     chunks[range].copy_from_slice(chunk.as_ref());
                 },
             });
             quote! {
-                fn hash_tree_root(&mut self, context: &ssz_rs::MerkleizationContext) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
+                fn hash_tree_root(&mut self) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
                     let mut chunks = vec![0u8; #field_count * #BYTES_PER_CHUNK];
                     #(#impl_by_field)*
-                    ssz_rs::internal::merkleize(&chunks, None, context)
+                    ssz_rs::internal::merkleize(&chunks, None)
                 }
             }
         }
@@ -395,8 +395,8 @@ fn derive_merkleization_impl(data: &Data) -> TokenStream {
                         quote_spanned! { variant.span() =>
                             Self::#variant_name(value) => {
                                 let selector = #i as u8 as usize;
-                                let data_root  = value.hash_tree_root(context)?;
-                                Ok(ssz_rs::internal::mix_in_selector(&data_root, selector, context))
+                                let data_root  = value.hash_tree_root()?;
+                                Ok(ssz_rs::internal::mix_in_selector(&data_root, selector))
                             }
                         }
                     }
@@ -405,7 +405,6 @@ fn derive_merkleization_impl(data: &Data) -> TokenStream {
                             Self::None => Ok(ssz_rs::internal::mix_in_selector(
                                 &ssz_rs::Node::default(),
                                 0,
-                                context,
                             )),
                         }
                     }
@@ -413,7 +412,7 @@ fn derive_merkleization_impl(data: &Data) -> TokenStream {
                 }
             });
             quote! {
-                fn hash_tree_root(&mut self, context: &ssz_rs::MerkleizationContext) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
+                fn hash_tree_root(&mut self) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
                     match self {
                             #(#hash_tree_root_by_variant)*
                     }


### PR DESCRIPTION
after working through some of the early caching work in #3, it looks like an "intrusive" caching design makes the most sense and because of this, the `Context` type removed in this PR does not pull its own weight...

the only "service" it was providing was a static set of "zero" hashes that can be inlined as global statics using the `lazy_static` crate commonly used for this purpose across the rust ecosystem.