### PR TITLE
Feat/no std

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Snowfork... fork
+
+The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (0.20.*).
+
 # ssz_rs ✂️
 
 [![build](https://github.com/ralexstokes/ssz_rs/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/ralexstokes/ssz_rs/actions/workflows/rust.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Snowfork... fork
 
-The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (0.20.*).
+The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (`0.20.*`).
 
 # ssz_rs ✂️
 

--- a/ssz_rs/Cargo.toml
+++ b/ssz_rs/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 [dependencies]
 thiserror = "1.0.25"
-bitvec = "0.22.3"
+bitvec = "0.20.1"
 ssz_rs_derive = { path = "../ssz_rs_derive", version = "0.7.0" }
 sha2 = "0.9.8"
 lazy_static = "1.4.0"

--- a/ssz_rs/Cargo.toml
+++ b/ssz_rs/Cargo.toml
@@ -15,7 +15,6 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.25"
 bitvec = "0.20.1"
 ssz_rs_derive = { path = "../ssz_rs_derive", version = "0.7.0" }
 sha2 = "0.9.8"

--- a/ssz_rs/Cargo.toml
+++ b/ssz_rs/Cargo.toml
@@ -20,9 +20,18 @@ bitvec = "0.20.1"
 ssz_rs_derive = { path = "../ssz_rs_derive", version = "0.7.0" }
 sha2 = "0.9.8"
 lazy_static = "1.4.0"
+# funty = "=1.1.0"
 
 [dev-dependencies]
 hex-literal = "0.3.3"
 hex = "0.4.3"
 snap = "1.0"
 project-root = "0.2.2"
+
+[features]
+default = ["std"]
+std = [
+    "bitvec/std",
+    "sha2/std",
+    "lazy_static/spin",
+]

--- a/ssz_rs/examples/container_with_some_types.rs
+++ b/ssz_rs/examples/container_with_some_types.rs
@@ -53,7 +53,7 @@ fn main() {
     let encoding = match serialize(&foo) {
         Ok(encoding) => encoding,
         Err(e) => {
-            eprintln!("some error encoding: {}", e);
+            eprintln!("some error encoding: {:?}", e);
             return;
         }
     };
@@ -61,7 +61,7 @@ fn main() {
     let mut restored_foo = match Foo::<4>::deserialize(&encoding) {
         Ok(value) => value,
         Err(e) => {
-            eprintln!("some error decoding: {}", e);
+            eprintln!("some error decoding: {:?}", e);
             return;
         }
     };

--- a/ssz_rs/src/array.rs
+++ b/ssz_rs/src/array.rs
@@ -4,6 +4,7 @@
 //! If/when this restriction is lifted in favor of const generics, the macro here
 //! can likely be simplified to a definition over `const N: usize`.
 use crate::de::{deserialize_homogeneous_composite, Deserialize, DeserializeError};
+use crate::std::{Vec, vec};
 use crate::merkleization::{
     merkleize, pack, MerkleizationError, Merkleized, Node, BYTES_PER_CHUNK,
 };

--- a/ssz_rs/src/bitlist.rs
+++ b/ssz_rs/src/bitlist.rs
@@ -4,10 +4,8 @@ use crate::merkleization::{
 };
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
+use crate::std::{Vec, vec, Deref, DerefMut, fmt};
 use bitvec::prelude::{BitSlice, BitVec, Lsb0};
-use std::fmt;
-use std::iter::FromIterator;
-use std::ops::{Deref, DerefMut};
 
 type BitlistInner = BitVec<Lsb0, u8>;
 
@@ -57,7 +55,7 @@ impl<const N: usize> Bitlist<N> {
 
     fn pack_bits(&self) -> Result<Vec<u8>, MerkleizationError> {
         let mut data = vec![];
-        let _ = self.serialize_with_length(&mut data, false)?;
+        let _ = self.serialize_with_length(&mut data, false).map_err(|_| MerkleizationError::SerializationError);
         pack_bytes(&mut data);
         Ok(data)
     }

--- a/ssz_rs/src/bitvector.rs
+++ b/ssz_rs/src/bitvector.rs
@@ -2,11 +2,9 @@ use crate::de::{Deserialize, DeserializeError};
 use crate::merkleization::{merkleize, pack_bytes, MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
+use crate::std::{Vec, vec, Deref, DerefMut, fmt};
 use bitvec::field::BitField;
 use bitvec::prelude::{BitVec, Lsb0};
-use std::fmt;
-use std::iter::FromIterator;
-use std::ops::{Deref, DerefMut};
 
 type BitvectorInner = BitVec<Lsb0, u8>;
 
@@ -65,7 +63,7 @@ impl<const N: usize> Bitvector<N> {
 
     fn pack_bits(&self) -> Result<Vec<u8>, MerkleizationError> {
         let mut data = vec![];
-        let _ = self.serialize(&mut data)?;
+        let _ = self.serialize(&mut data).map_err(|_| MerkleizationError::SerializationError);
         pack_bytes(&mut data);
         Ok(data)
     }

--- a/ssz_rs/src/boolean.rs
+++ b/ssz_rs/src/boolean.rs
@@ -2,6 +2,7 @@ use crate::de::{Deserialize, DeserializeError};
 use crate::merkleization::{MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
+use crate::std::{Vec};
 
 impl Sized for bool {
     fn is_variable_size() -> bool {

--- a/ssz_rs/src/de.rs
+++ b/ssz_rs/src/de.rs
@@ -1,21 +1,14 @@
 use crate::ser::BYTES_PER_LENGTH_OFFSET;
 use crate::SimpleSerialize;
-use thiserror::Error;
+use crate::std::{Vec, vec};
 
-#[derive(Error, Debug)]
-#[error("the value could not be deserialized: {0}")]
+#[derive(Debug)]
 pub enum DeserializeError {
-    #[error("expected further data when decoding")]
-    InputTooShort,
-    #[error("unexpected additional data provided when decoding")]
-    ExtraInput,
-    #[error("invalid data for expected type")]
+    InputTooShort, // unexpected additional data provided when decoding
+    ExtraInput, // invalid data for expected type
     InvalidInput,
-    #[error("{0}")]
-    IOError(#[from] std::io::Error),
-    #[error("the type for this value has a bound of {bound} but the value has {len} elements")]
+    IOError,
     TypeBoundsViolated { bound: usize, len: usize },
-    #[error("the type for this value has an illegal bound of {bound}")]
     IllegalType { bound: usize },
 }
 

--- a/ssz_rs/src/lib.rs
+++ b/ssz_rs/src/lib.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 mod array;
 mod bitlist;
 mod bitvector;
@@ -10,6 +15,7 @@ mod ser;
 mod uint;
 mod union;
 mod vector;
+mod std;
 
 use crate::list::Error as ListError;
 use crate::vector::Error as VectorError;

--- a/ssz_rs/src/lib.rs
+++ b/ssz_rs/src/lib.rs
@@ -17,17 +17,14 @@ mod union;
 mod vector;
 mod std;
 
-use crate::list::Error as ListError;
-use crate::vector::Error as VectorError;
+pub use crate::std::{Vec, vec, Option};
 pub use bitlist::Bitlist;
 pub use bitvector::Bitvector;
 pub use de::{Deserialize, DeserializeError};
 pub use list::List;
 pub use merkleization::{Context as MerkleizationContext, MerkleizationError, Merkleized, Node};
 pub use ser::{Serialize, SerializeError};
-use thiserror::Error;
 pub use uint::U256;
-pub use vector::Vector;
 
 /// `Sized` is a trait for types that can
 /// provide sizing information relevant for the SSZ spec.
@@ -68,14 +65,13 @@ where
     T::deserialize(encoding)
 }
 
-#[derive(Debug, Error)]
-#[error("{0}")]
+#[derive(Debug)]
 pub enum SimpleSerializeError {
-    Serialize(#[from] SerializeError),
-    Deserialize(#[from] DeserializeError),
-    Merkleization(#[from] MerkleizationError),
-    List(#[from] ListError),
-    Vector(#[from] VectorError),
+    Serialize,
+    Deserialize,
+    Merkleization,
+    List,
+    Vector,
 }
 
 /// The `prelude` contains common traits and types a user of this library

--- a/ssz_rs/src/list.rs
+++ b/ssz_rs/src/list.rs
@@ -4,17 +4,12 @@ use crate::merkleization::{
     BYTES_PER_CHUNK,
 };
 use crate::ser::{serialize_composite, Serialize, SerializeError};
-use crate::{SimpleSerialize, SimpleSerializeError, Sized};
-use std::iter::{Enumerate, FromIterator};
-use std::ops::{Deref, Index, IndexMut};
-use std::slice::SliceIndex;
-use std::{fmt, slice};
-use thiserror::Error;
+use crate::{SimpleSerialize, Sized};
+use crate::std::{Enumerate, FromIterator, Vec, fmt, SliceIndex, Deref, Index, IndexMut, IterMut as StdIterMut};
 
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("{provided} elements given that exceeds the list bound of {expected}")]
-    IncorrectLength { expected: usize, provided: usize },
+#[derive(Debug)]
+pub enum ListError {
+    IncorrectLength , // elements given that exceeds the list bound of
 }
 
 /// A homogenous collection of a variable number of values.
@@ -48,14 +43,11 @@ impl<T, const N: usize> TryFrom<Vec<T>> for List<T, N>
 where
     T: SimpleSerialize,
 {
-    type Error = SimpleSerializeError;
+    type Error = ListError;
 
     fn try_from(data: Vec<T>) -> Result<Self, Self::Error> {
         if data.len() > N {
-            Err(SimpleSerializeError::List(Error::IncorrectLength {
-                expected: N,
-                provided: data.len(),
-            }))
+            Err(ListError::IncorrectLength)
         } else {
             let leaf_count = Self::get_leaf_count(data.len());
             Ok(Self {
@@ -219,7 +211,7 @@ pub struct IterMut<'a, T, const N: usize>
 where
     T: SimpleSerialize,
 {
-    inner: Enumerate<slice::IterMut<'a, T>>,
+    inner: Enumerate<StdIterMut<'a, T>>,
     cache: &'a mut MerkleCache,
 }
 

--- a/ssz_rs/src/merkleization/node.rs
+++ b/ssz_rs/src/merkleization/node.rs
@@ -1,8 +1,5 @@
 use crate::prelude::*;
-use std::array::TryFromSliceError;
-use std::convert::AsRef;
-use std::fmt;
-use std::ops::{Index, IndexMut};
+use crate::std::{Index, IndexMut, Vec, vec, TryFromSliceError, fmt, AsRef};
 
 #[derive(Default, Clone, Copy, PartialEq, Eq, SimpleSerialize)]
 pub struct Node(pub(crate) [u8; 32]);

--- a/ssz_rs/src/ser.rs
+++ b/ssz_rs/src/ser.rs
@@ -1,19 +1,15 @@
 use crate::SimpleSerialize;
-use thiserror::Error;
+use crate::std::{Vec, vec};
 
 // NOTE: if this is changed, go change in `ssz_derive` as well!
 pub const BYTES_PER_LENGTH_OFFSET: usize = 4;
 const MAXIMUM_LENGTH: usize = 2usize.pow((BYTES_PER_LENGTH_OFFSET * 8) as u32);
 
-#[derive(Error, Debug)]
-#[error("the value could not be serialized: {0}")]
+#[derive(Debug)]
 pub enum SerializeError {
-    #[error("the encoded length is {0} which exceeds the maximum length {MAXIMUM_LENGTH}")]
-    MaximumEncodedLengthExceeded(usize),
-    #[error("the type for this value has a bound of {bound} but the value has {len} elements")]
-    TypeBoundsViolated { bound: usize, len: usize },
-    #[error("the type for this value has an illegal bound of {bound}")]
-    IllegalType { bound: usize },
+    MaximumEncodedLengthExceeded(usize), // the encoded length is {0} which exceeds the maximum length {MAXIMUM_LENGTH}
+    TypeBoundsViolated { bound: usize, len: usize }, // the type for this value has a bound of {bound} but the value has {len} elements"
+    IllegalType { bound: usize }, // the type for this value has an illegal bound of {bound}
 }
 
 pub trait Serialize {

--- a/ssz_rs/src/std.rs
+++ b/ssz_rs/src/std.rs
@@ -1,0 +1,16 @@
+// Copyright 2020 Snowfork
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE or
+// http://www.apache.org/licenses/LICENSE-2.0>. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[cfg(not(feature = "std"))]
+pub use alloc::{vec, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+pub use core::{option, ops, slice};
+
+#[cfg(feature = "std")]
+pub use std::{vec, vec::Vec, error, option, convert, fmt};

--- a/ssz_rs/src/std.rs
+++ b/ssz_rs/src/std.rs
@@ -6,11 +6,10 @@
 // http://www.apache.org/licenses/LICENSE-2.0>. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#[cfg(feature = "std")]
+pub use std::{ops::DerefMut, ops::Deref, ops::Index, ops::IndexMut, array::TryFromSliceError, slice::IterMut, vec, vec::Vec, error, option::Option, cmp::Ordering, convert::AsRef, convert::TryFrom, convert::TryInto, fmt, iter::FromIterator, iter::Enumerate, slice::SliceIndex, fmt::Debug, default::Default};
+
 #[cfg(not(feature = "std"))]
 pub use alloc::{vec, vec::Vec};
-
 #[cfg(not(feature = "std"))]
-pub use core::{option, ops, slice};
-
-#[cfg(feature = "std")]
-pub use std::{vec, vec::Vec, error, option, convert, fmt};
+pub use core::{ops::DerefMut, ops::Deref, ops::Index, ops::IndexMut, slice::SliceIndex, slice::IterMut, option::Option, array::TryFromSliceError, iter::FromIterator, iter::Enumerate, convert::TryFrom, convert::TryInto, convert::AsRef, fmt, fmt::Debug, cmp::Ordering, default::Default};

--- a/ssz_rs/src/uint.rs
+++ b/ssz_rs/src/uint.rs
@@ -2,8 +2,7 @@ use crate::de::{Deserialize, DeserializeError};
 use crate::merkleization::{pack_bytes, MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
-use std::convert::TryInto;
-use std::default::Default;
+use crate::std::{Vec, vec, Debug, Default, TryInto};
 
 macro_rules! define_uint {
     ($uint:ty) => {
@@ -44,7 +43,7 @@ macro_rules! define_uint {
         impl Merkleized for $uint {
             fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
                 let mut root = vec![];
-                let _ = self.serialize(&mut root)?;
+                let _ = self.serialize(&mut root).map_err(|_| MerkleizationError::SerializationError);
                 pack_bytes(&mut root);
                 Ok(root.as_slice().try_into().expect("is valid root"))
             }

--- a/ssz_rs/src/union.rs
+++ b/ssz_rs/src/union.rs
@@ -2,6 +2,7 @@ use crate::de::{Deserialize, DeserializeError};
 use crate::merkleization::{mix_in_selector, MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
+use crate::std::Vec;
 
 /// `SimpleSerialize` is implemented for `Option` as a convenience
 /// when the schema is equivalent to one described by:


### PR DESCRIPTION
- Pins `bitvec` + `funty` versions to versions compatible to the versions used in Substrate.
- Updates bitlist module to work with the older version of `bitvec`
- Adds `std` feature that is enabled by default
- Adds `std` module to import dependencies from `std` (for std) and `alloc` / `core` (for no-std)
- Removes dependency `thiserror` because it relies on `std`