### PR TITLE
No-std support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,38 +1,28 @@
-on: [push]
-
 name: Rust
 
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  build_and_test:
+  build:
+
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
-        name: Checkout
-
-      - uses: actions-rs/toolchain@v1
-        name: Checkout stable toolchain
-        with:
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@v1
-
-      - uses: actions-rs/cargo@v1
-        name: Build std
-        with:
-          command: build
-          args: --release
-
-      - uses: actions-rs/cargo@v1
-        name: Build no-std
-        with:
-          command: build
-          args: --release --no-default-features
-
-      - uses: actions-rs/cargo@v1
-        name: Tests
-        with:
-          command: test
-
-      - uses: actions-rs/cargo@v1
-        name: Run clippy
+      - name: Install
+        run: rustup update stable
+      - name: Build Std
+        run: cargo build --verbose --release
+      - name: Build No-Std
+        run: cargo build --verbose --release --no-default-features
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Run clippy
         run: cargo clippy --verbose -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,3 +32,7 @@ jobs:
         name: Tests
         with:
           command: test
+
+      - uses: actions-rs/cargo@v1
+        name: Run clippy
+        run: cargo clippy --verbose -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,26 +1,34 @@
+on: [push]
+
 name: Rust
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
-  build:
-
+  build_and_test:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Install
-      run: rustup update stable
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run clippy
-      run: cargo clippy --verbose -- -D warnings
+      - uses: actions/checkout@v2
+        name: Checkout
+
+      - uses: actions-rs/toolchain@v1
+        name: Checkout stable toolchain
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: actions-rs/cargo@v1
+        name: Build std
+        with:
+          command: build
+          args: --release
+
+      - uses: actions-rs/cargo@v1
+        name: Build no-std
+        with:
+          command: build
+          args: --release --no-default-features
+
+      - uses: actions-rs/cargo@v1
+        name: Tests
+        with:
+          command: test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Snowfork... fork
+
+The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (0.20.*).
+
 # ssz_rs ✂️
 
 [![build](https://github.com/ralexstokes/ssz_rs/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/ralexstokes/ssz_rs/actions/workflows/rust.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Snowfork... fork
 
-The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (0.20.*).
+The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (`0.20.*`).
 
 # ssz_rs ✂️
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Snowfork... fork
 
-The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (`0.20.*`).
+The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (`0.20.*`). It also supports running in a no-std environment.
 
 # ssz_rs ✂️
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Snowfork... fork
-
-The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (`0.20.*`). It also supports running in a no-std environment.
-
 # ssz_rs ✂️
 
 [![build](https://github.com/ralexstokes/ssz_rs/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/ralexstokes/ssz_rs/actions/workflows/rust.yml)

--- a/ssz_rs/Cargo.toml
+++ b/ssz_rs/Cargo.toml
@@ -15,11 +15,11 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitvec = "0.20.1"
+thiserror = "1.0.25"
+bitvec = "0.22.3"
 ssz_rs_derive = { path = "../ssz_rs_derive", version = "0.7.0" }
 sha2 = "0.9.8"
 lazy_static = "1.4.0"
-funty = "=1.1.0"
 
 [dev-dependencies]
 hex-literal = "0.3.3"

--- a/ssz_rs/Cargo.toml
+++ b/ssz_rs/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 [dependencies]
 thiserror = "1.0.25"
-bitvec = "0.22.3"
+bitvec = "0.20.1"
 ssz_rs_derive = { path = "../ssz_rs_derive", version = "0.7.0" }
 sha2 = "0.9.8"
 lazy_static = "1.4.0"

--- a/ssz_rs/Cargo.toml
+++ b/ssz_rs/Cargo.toml
@@ -15,12 +15,11 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.25"
 bitvec = "0.20.1"
 ssz_rs_derive = { path = "../ssz_rs_derive", version = "0.7.0" }
 sha2 = "0.9.8"
 lazy_static = "1.4.0"
-# funty = "=1.1.0"
+funty = "=1.1.0"
 
 [dev-dependencies]
 hex-literal = "0.3.3"

--- a/ssz_rs/Cargo.toml
+++ b/ssz_rs/Cargo.toml
@@ -20,9 +20,18 @@ bitvec = "0.20.1"
 ssz_rs_derive = { path = "../ssz_rs_derive", version = "0.7.0" }
 sha2 = "0.9.8"
 lazy_static = "1.4.0"
+# funty = "=1.1.0"
 
 [dev-dependencies]
 hex-literal = "0.3.3"
 hex = "0.4.3"
 snap = "1.0"
 project-root = "0.2.2"
+
+[features]
+default = ["std"]
+std = [
+    "bitvec/std",
+    "sha2/std",
+    "lazy_static/spin",
+]

--- a/ssz_rs/examples/container_with_some_types.rs
+++ b/ssz_rs/examples/container_with_some_types.rs
@@ -53,7 +53,7 @@ fn main() {
     let encoding = match serialize(&foo) {
         Ok(encoding) => encoding,
         Err(e) => {
-            eprintln!("some error encoding: {}", e);
+            eprintln!("some error encoding: {:?}", e);
             return;
         }
     };
@@ -61,7 +61,7 @@ fn main() {
     let mut restored_foo = match Foo::<4>::deserialize(&encoding) {
         Ok(value) => value,
         Err(e) => {
-            eprintln!("some error decoding: {}", e);
+            eprintln!("some error decoding: {:?}", e);
             return;
         }
     };

--- a/ssz_rs/src/array.rs
+++ b/ssz_rs/src/array.rs
@@ -4,6 +4,7 @@
 //! If/when this restriction is lifted in favor of const generics, the macro here
 //! can likely be simplified to a definition over `const N: usize`.
 use crate::de::{deserialize_homogeneous_composite, Deserialize, DeserializeError};
+use crate::std::{Vec, vec};
 use crate::merkleization::{
     merkleize, pack, MerkleizationError, Merkleized, Node, BYTES_PER_CHUNK,
 };

--- a/ssz_rs/src/bitlist.rs
+++ b/ssz_rs/src/bitlist.rs
@@ -4,10 +4,8 @@ use crate::merkleization::{
 };
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
+use crate::std::{Vec, vec, Deref, DerefMut, fmt, FromIterator};
 use bitvec::prelude::{BitSlice, BitVec, Lsb0};
-use std::fmt;
-use std::iter::FromIterator;
-use std::ops::{Deref, DerefMut};
 
 type BitlistInner = BitVec<Lsb0, u8>;
 
@@ -57,7 +55,7 @@ impl<const N: usize> Bitlist<N> {
 
     fn pack_bits(&self) -> Result<Vec<u8>, MerkleizationError> {
         let mut data = vec![];
-        let _ = self.serialize_with_length(&mut data, false)?;
+        let _ = self.serialize_with_length(&mut data, false).map_err(|_| MerkleizationError::SerializationError);
         pack_bytes(&mut data);
         Ok(data)
     }

--- a/ssz_rs/src/bitvector.rs
+++ b/ssz_rs/src/bitvector.rs
@@ -2,11 +2,9 @@ use crate::de::{Deserialize, DeserializeError};
 use crate::merkleization::{merkleize, pack_bytes, MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
+use crate::std::{Vec, vec, Deref, DerefMut, fmt, FromIterator};
 use bitvec::field::BitField;
 use bitvec::prelude::{BitVec, Lsb0};
-use std::fmt;
-use std::iter::FromIterator;
-use std::ops::{Deref, DerefMut};
 
 type BitvectorInner = BitVec<Lsb0, u8>;
 
@@ -65,7 +63,7 @@ impl<const N: usize> Bitvector<N> {
 
     fn pack_bits(&self) -> Result<Vec<u8>, MerkleizationError> {
         let mut data = vec![];
-        let _ = self.serialize(&mut data)?;
+        let _ = self.serialize(&mut data).map_err(|_| MerkleizationError::SerializationError);
         pack_bytes(&mut data);
         Ok(data)
     }

--- a/ssz_rs/src/boolean.rs
+++ b/ssz_rs/src/boolean.rs
@@ -2,6 +2,7 @@ use crate::de::{Deserialize, DeserializeError};
 use crate::merkleization::{MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
+use crate::std::{Vec};
 
 impl Sized for bool {
     fn is_variable_size() -> bool {

--- a/ssz_rs/src/de.rs
+++ b/ssz_rs/src/de.rs
@@ -1,22 +1,15 @@
 use crate::ser::BYTES_PER_LENGTH_OFFSET;
 use crate::SimpleSerialize;
-use thiserror::Error;
+use crate::std::{Vec, vec};
 
-#[derive(Error, Debug)]
-#[error("the value could not be deserialized: {0}")]
+#[derive(Debug)]
 pub enum DeserializeError {
-    #[error("expected further data when decoding")]
-    InputTooShort,
-    #[error("unexpected additional data provided when decoding")]
-    ExtraInput,
-    #[error("invalid data for expected type")]
-    InvalidInput,
-    #[error("{0}")]
-    IOError(#[from] std::io::Error),
-    #[error("the type for this value has a bound of {bound} but the value has {len} elements")]
-    TypeBoundsViolated { bound: usize, len: usize },
-    #[error("the type for this value has an illegal bound of {bound}")]
-    IllegalType { bound: usize },
+    InputTooShort, // unexpected additional data provided when decoding
+    ExtraInput, // invalid data for expected type
+    InvalidInput, // invalid data for expected type
+    IOError,
+    TypeBoundsViolated { bound: usize, len: usize }, // the type for this value has a bound of {bound} but the value has {len} elements
+    IllegalType { bound: usize }, // the type for this value has an illegal bound of {bound}
 }
 
 pub trait Deserialize {

--- a/ssz_rs/src/lib.rs
+++ b/ssz_rs/src/lib.rs
@@ -17,17 +17,14 @@ mod union;
 mod vector;
 mod std;
 
-use crate::list::Error as ListError;
-use crate::vector::Error as VectorError;
+pub use crate::std::{Vec, vec};
 pub use bitlist::Bitlist;
 pub use bitvector::Bitvector;
 pub use de::{Deserialize, DeserializeError};
 pub use list::List;
 pub use merkleization::{Context as MerkleizationContext, MerkleizationError, Merkleized, Node};
 pub use ser::{Serialize, SerializeError};
-use thiserror::Error;
 pub use uint::U256;
-pub use vector::Vector;
 
 /// `Sized` is a trait for types that can
 /// provide sizing information relevant for the SSZ spec.
@@ -68,14 +65,13 @@ where
     T::deserialize(encoding)
 }
 
-#[derive(Debug, Error)]
-#[error("{0}")]
+#[derive(Debug)]
 pub enum SimpleSerializeError {
-    Serialize(#[from] SerializeError),
-    Deserialize(#[from] DeserializeError),
-    Merkleization(#[from] MerkleizationError),
-    List(#[from] ListError),
-    Vector(#[from] VectorError),
+    Serialize,
+    Deserialize,
+    Merkleization,
+    List,
+    Vector,
 }
 
 /// The `prelude` contains common traits and types a user of this library

--- a/ssz_rs/src/lib.rs
+++ b/ssz_rs/src/lib.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 mod array;
 mod bitlist;
 mod bitvector;
@@ -10,6 +15,7 @@ mod ser;
 mod uint;
 mod union;
 mod vector;
+mod std;
 
 use crate::list::Error as ListError;
 use crate::vector::Error as VectorError;

--- a/ssz_rs/src/merkleization/mod.rs
+++ b/ssz_rs/src/merkleization/mod.rs
@@ -2,13 +2,10 @@ mod cache;
 mod node;
 mod proofs;
 
-use crate::ser::{Serialize, SerializeError};
+use crate::ser::{Serialize};
+use crate::std::{Index, Vec, vec, Option, Debug, Ordering, fmt};
 use lazy_static::lazy_static;
 use sha2::{Digest, Sha256};
-use std::cmp::Ordering;
-use std::fmt::Debug;
-use std::ops::Index;
-use thiserror::Error;
 
 pub use cache::Cache as MerkleCache;
 pub use node::Node;
@@ -24,15 +21,11 @@ pub trait Merkleized {
     fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError>;
 }
 
-#[derive(Error, Debug)]
-#[error("the value could not be merkleized: {0}")]
+#[derive(Debug)]
 pub enum MerkleizationError {
-    #[error("failed to serialize value: {0}")]
-    SerializationError(#[from] SerializeError),
-    #[error("cannot merkleize a partial chunk of length {1} (data: {0:?})")]
-    PartialChunk(Vec<u8>, usize),
-    #[error("cannot merkleize data that exceeds the declared limit {0}")]
-    InputExceedsLimit(usize),
+    SerializationError, // failed to serialize value
+    PartialChunk(Vec<u8>, usize), // cannot merkleize a partial chunk of length {1} (data: {0:?})
+    InputExceedsLimit(usize), // cannot merkleize data that exceeds the declared limit {0}
 }
 
 pub fn pack_bytes(buffer: &mut Vec<u8>) {
@@ -52,7 +45,7 @@ where
 {
     let mut buffer = vec![];
     for value in values {
-        value.serialize(&mut buffer)?;
+        value.serialize(&mut buffer).map_err(|_| MerkleizationError::SerializationError)?;
     }
     pack_bytes(&mut buffer);
     Ok(buffer)
@@ -97,7 +90,7 @@ impl Default for Context {
 }
 
 impl Debug for Context {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Context")
             .field("zero_hashes", &"...")
             .finish()

--- a/ssz_rs/src/merkleization/node.rs
+++ b/ssz_rs/src/merkleization/node.rs
@@ -1,8 +1,5 @@
 use crate::prelude::*;
-use std::array::TryFromSliceError;
-use std::convert::AsRef;
-use std::fmt;
-use std::ops::{Index, IndexMut};
+use crate::std::{Index, IndexMut, Vec, vec, TryFromSliceError, fmt, AsRef};
 
 #[derive(Default, Clone, Copy, PartialEq, Eq, SimpleSerialize)]
 pub struct Node(pub(crate) [u8; 32]);

--- a/ssz_rs/src/ser.rs
+++ b/ssz_rs/src/ser.rs
@@ -1,19 +1,15 @@
 use crate::SimpleSerialize;
-use thiserror::Error;
+use crate::std::{Vec, vec};
 
 // NOTE: if this is changed, go change in `ssz_derive` as well!
 pub const BYTES_PER_LENGTH_OFFSET: usize = 4;
 const MAXIMUM_LENGTH: usize = 2usize.pow((BYTES_PER_LENGTH_OFFSET * 8) as u32);
 
-#[derive(Error, Debug)]
-#[error("the value could not be serialized: {0}")]
+#[derive(Debug)]
 pub enum SerializeError {
-    #[error("the encoded length is {0} which exceeds the maximum length {MAXIMUM_LENGTH}")]
-    MaximumEncodedLengthExceeded(usize),
-    #[error("the type for this value has a bound of {bound} but the value has {len} elements")]
-    TypeBoundsViolated { bound: usize, len: usize },
-    #[error("the type for this value has an illegal bound of {bound}")]
-    IllegalType { bound: usize },
+    MaximumEncodedLengthExceeded(usize), // the encoded length is {0} which exceeds the maximum length {MAXIMUM_LENGTH}
+    TypeBoundsViolated { bound: usize, len: usize }, // the type for this value has a bound of {bound} but the value has {len} elements"
+    IllegalType { bound: usize }, // the type for this value has an illegal bound of {bound}
 }
 
 pub trait Serialize {

--- a/ssz_rs/src/std.rs
+++ b/ssz_rs/src/std.rs
@@ -1,0 +1,16 @@
+// Copyright 2020 Snowfork
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE or
+// http://www.apache.org/licenses/LICENSE-2.0>. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[cfg(not(feature = "std"))]
+pub use alloc::{vec, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+pub use core::{option, ops, slice};
+
+#[cfg(feature = "std")]
+pub use std::{vec, vec::Vec, error, option, convert, fmt};

--- a/ssz_rs/src/std.rs
+++ b/ssz_rs/src/std.rs
@@ -1,11 +1,3 @@
-// Copyright 2020 Snowfork
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE or
-// http://www.apache.org/licenses/LICENSE-2.0>. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 #[cfg(feature = "std")]
 pub use std::{array::TryFromSliceError, cmp::Ordering, convert::AsRef, convert::TryFrom, convert::TryInto, default::Default, fmt, fmt::Debug, iter::FromIterator, iter::Enumerate, ops::DerefMut, ops::Deref, ops::Index, ops::IndexMut, option::Option, slice::IterMut, slice::SliceIndex, vec, vec::Vec};
 

--- a/ssz_rs/src/std.rs
+++ b/ssz_rs/src/std.rs
@@ -6,11 +6,10 @@
 // http://www.apache.org/licenses/LICENSE-2.0>. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#[cfg(feature = "std")]
+pub use std::{array::TryFromSliceError, cmp::Ordering, convert::AsRef, convert::TryFrom, convert::TryInto, default::Default, fmt, fmt::Debug, iter::FromIterator, iter::Enumerate, ops::DerefMut, ops::Deref, ops::Index, ops::IndexMut, option::Option, slice::IterMut, slice::SliceIndex, vec, vec::Vec};
+
 #[cfg(not(feature = "std"))]
 pub use alloc::{vec, vec::Vec};
-
 #[cfg(not(feature = "std"))]
-pub use core::{option, ops, slice};
-
-#[cfg(feature = "std")]
-pub use std::{vec, vec::Vec, error, option, convert, fmt};
+pub use core::{array::TryFromSliceError, cmp::Ordering, convert::AsRef, convert::TryFrom, convert::TryInto, default::Default, fmt, fmt::Debug, iter::Enumerate, iter::FromIterator, ops::DerefMut, ops::Deref, ops::Index, ops::IndexMut, option::Option, slice::IterMut, slice::SliceIndex};

--- a/ssz_rs/src/uint.rs
+++ b/ssz_rs/src/uint.rs
@@ -2,8 +2,7 @@ use crate::de::{Deserialize, DeserializeError};
 use crate::merkleization::{pack_bytes, MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
-use std::convert::TryInto;
-use std::default::Default;
+use crate::std::{Vec, vec, Debug, Default, TryInto};
 
 macro_rules! define_uint {
     ($uint:ty) => {
@@ -44,7 +43,7 @@ macro_rules! define_uint {
         impl Merkleized for $uint {
             fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
                 let mut root = vec![];
-                let _ = self.serialize(&mut root)?;
+                let _ = self.serialize(&mut root).map_err(|_| MerkleizationError::SerializationError);
                 pack_bytes(&mut root);
                 Ok(root.as_slice().try_into().expect("is valid root"))
             }

--- a/ssz_rs/src/union.rs
+++ b/ssz_rs/src/union.rs
@@ -2,6 +2,7 @@ use crate::de::{Deserialize, DeserializeError};
 use crate::merkleization::{mix_in_selector, MerkleizationError, Merkleized, Node};
 use crate::ser::{Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
+use crate::std::Vec;
 
 /// `SimpleSerialize` is implemented for `Option` as a convenience
 /// when the schema is equivalent to one described by:

--- a/ssz_rs/src/vector.rs
+++ b/ssz_rs/src/vector.rs
@@ -2,19 +2,13 @@ use crate::de::{deserialize_homogeneous_composite, Deserialize, DeserializeError
 use crate::merkleization::{
     merkleize, pack, MerkleCache, MerkleizationError, Merkleized, Node, BYTES_PER_CHUNK,
 };
-use crate::ser::{serialize_composite, Serialize, SerializeError};
-use crate::{SimpleSerialize, SimpleSerializeError, Sized};
-use std::convert::TryFrom;
-use std::fmt;
-use std::iter::FromIterator;
-use std::ops::{Deref, Index, IndexMut};
-use std::slice::SliceIndex;
-use thiserror::Error;
+use crate::ser::{serialize_composite, Serialize};
+use crate::{SerializeError, SimpleSerialize, Sized};
+use crate::std::{Vec, vec, SliceIndex, IndexMut, Index, Deref, TryFrom, fmt};
 
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("incorrect number of elements {provided} to make a Vector of length {expected}")]
-    IncorrectLength { expected: usize, provided: usize },
+#[derive(Debug)]
+pub enum VectorError {
+    IncorrectLength { expected: usize, provided: usize }, // incorrect number of elements {provided} to make a Vector of length {expected}
 }
 
 /// A homogenous collection of a fixed number of values.
@@ -34,14 +28,14 @@ impl<T: SimpleSerialize + PartialEq, const N: usize> PartialEq for Vector<T, N> 
 impl<T: SimpleSerialize + Eq, const N: usize> Eq for Vector<T, N> {}
 
 impl<T: SimpleSerialize, const N: usize> TryFrom<Vec<T>> for Vector<T, N> {
-    type Error = SimpleSerializeError;
+    type Error = VectorError;
 
     fn try_from(data: Vec<T>) -> Result<Self, Self::Error> {
         if data.len() != N {
-            Err(SimpleSerializeError::Vector(Error::IncorrectLength {
+            Err(VectorError::IncorrectLength {
                 expected: N,
                 provided: data.len(),
-            }))
+            })
         } else {
             let leaf_count = Self::get_leaf_count();
             Ok(Self {
@@ -155,14 +149,13 @@ where
         }
         let data = deserialize_homogeneous_composite(encoding)?;
         data.try_into().map_err(|err| match err {
-            SimpleSerializeError::Vector(Error::IncorrectLength { expected, provided }) => {
+            VectorError::IncorrectLength { expected, provided } => {
                 if expected < provided {
                     DeserializeError::ExtraInput
                 } else {
                     DeserializeError::InputTooShort
                 }
             }
-            _ => unreachable!("variants not returned from `try_into`"),
         })
     }
 }


### PR DESCRIPTION
- Removes use of `thiserror` since it doesn't support no-std
- Added mod std to import features from either std or core/alloc, based on default features
- Added build with `--no-default-features` to Github Actions workflow